### PR TITLE
move transaction distribution from metadata to summary

### DIFF
--- a/src/main/java/com/oltpbenchmark/util/ResultWriter.java
+++ b/src/main/java/com/oltpbenchmark/util/ResultWriter.java
@@ -237,6 +237,16 @@ public class ResultWriter {
     }
 
     public Map<String, Object> writeDetailedSummary(PrintStream os) {
+        Map<String, Object> transactionsMap = new TreeMap<>();
+        transactionsMap.put("Completed Transactions", results.getSuccess().getSampleCount());
+        transactionsMap.put("Aborted Transactions", results.getAbort().getSampleCount());
+        transactionsMap.put("Rejected Transactions (Server Retry)", results.getRetry().getSampleCount());
+        transactionsMap.put("Rejected Transactions (Retry Different)", results.getRetryDifferent().getSampleCount());
+        transactionsMap.put("Unexpected SQL Errors", results.getError().getSampleCount());
+        transactionsMap.put("Unknown Status Transactions", results.getUnknown().getSampleCount());
+        transactionsMap.put("Zero Rows Returned", results.getZeroRows().getSampleCount());
+        transactionsMap.put("Total measured requests", results.getMeasuredRequests());
+
         Map<String, Object> summaryMap = new TreeMap<>();
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         Date now = new Date();
@@ -247,20 +257,14 @@ public class ResultWriter {
         summaryMap.put("Latency Distribution", results.getDistributionStatistics().toMap());
         summaryMap.put("Throughput (requests/second)", results.requestsPerSecondThroughput());
         summaryMap.put("Goodput (requests/second)", results.requestsPerSecondGoodput());
+        summaryMap.put("Transaction Distribution", transactionsMap);
+
         for (String field : BENCHMARK_KEY_FIELD) {
             summaryMap.put(field, expConf.getString(field));
         }
         Map<String, Object> detailedSummaryMap = new TreeMap<>();
         Map<String, Object> metadata = new TreeMap<>();
         metadata.put("yaml_version", expConf.getString("yaml_version", "v1.0"));
-        metadata.put("Completed Transactions", results.getSuccess().getSampleCount());
-        metadata.put("Aborted Transactions", results.getAbort().getSampleCount());
-        metadata.put("Rejected Transactions (Server Retry)", results.getRetry().getSampleCount());
-        metadata.put("Rejected Transactions (Retry Different)", results.getRetryDifferent().getSampleCount());
-        metadata.put("Unexpected SQL Errors", results.getError().getSampleCount());
-        metadata.put("Unknown Status Transactions", results.getUnknown().getSampleCount());
-        metadata.put("Zero Rows Returned", results.getZeroRows().getSampleCount());
-        metadata.put("Total measured requests", results.getMeasuredRequests());
         detailedSummaryMap.put("metadata", metadata);
         detailedSummaryMap.put("Summary", summaryMap);
         detailedSummaryMap.put("queries", results.getFeaturebenchAdditionalResults().getJsonResultsList());


### PR DESCRIPTION
Moved transaction count distribution from metadata to summary. This information will be available in ```.detailed.json``` and ```output.json``` files and will look like this:

```
{
  "scalefactor": null,
  "Current Timestamp (milliseconds)": 1687345882611,
  "Benchmark Type": "featurebench",
  "isolation": "TRANSACTION_REPEATABLE_READ",
  "DBMS Version": "PostgreSQL 11.2-YB-2.15.2.0-b0 on x86_64-pc-linux-gnu, compiled by clang version 13.0.1 (https://github.com/yugabyte/llvm-project.git 191e3a05a55c8671bcc88d7387c04c55a4310500), 64-bit",
  "Goodput (requests/second)": 61.00867605398975,
  "Transaction Distribution": {
   "Rejected Transactions (Server Retry)": 0,
   "Rejected Transactions (Retry Different)": 0,
   "Zero Rows Returned": 0,
   "Total measured requests": 341,
   "Completed Transactions": 366,
   "Aborted Transactions": 0,
   "Unknown Status Transactions": 0,
   "Unexpected SQL Errors": 0
  },
  "terminals": "1",
  "DBMS Type": "YUGABYTE",
  "Latency Distribution": {
   "95th Percentile Latency (microseconds)": 21241,
   "Maximum Latency (microseconds)": 36750,
   "Median Latency (microseconds)": 17399,
   "Minimum Latency (microseconds)": 13619,
   "25th Percentile Latency (microseconds)": 15691,
   "90th Percentile Latency (microseconds)": 20406,
   "99th Percentile Latency (microseconds)": 23638,
   "75th Percentile Latency (microseconds)": 18990,
   "Average Latency (microseconds)": 17540
  },
  "Throughput (requests/second)": 56.841416760684446
 }
```