### PR TITLE
perfinfra-185: fix pg_stat_statement collection in multithreaded case

### DIFF
--- a/src/main/java/com/oltpbenchmark/ThreadBench.java
+++ b/src/main/java/com/oltpbenchmark/ThreadBench.java
@@ -338,12 +338,6 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                 results.getRetryDifferent().putHistogram(w.getTransactionRetryDifferentHistogram());
                 results.getZeroRows().putHistogram(w.getTransactionZeroRowsHistogram());
                 results.getFeaturebenchAdditionalResults().setJsonResultsList(w.featurebenchAdditionalResults.getJsonResultsList());
-                /*int currentLength = w.featurebenchAdditionalResults.getJsonResultsList().size();
-                int length = 0;
-                if(currentLength > length) {
-                    length = currentLength;
-                    results.getFeaturebenchAdditionalResults().setJsonResultsList(w.featurebenchAdditionalResults.getJsonResultsList());
-                }*/
             }
 
             return (results);

--- a/src/main/java/com/oltpbenchmark/ThreadBench.java
+++ b/src/main/java/com/oltpbenchmark/ThreadBench.java
@@ -329,6 +329,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
             results.getError().putAll(txnTypes, 0);
             results.getRetryDifferent().putAll(txnTypes, 0);
             results.getZeroRows().putAll(txnTypes, 0);
+
             for (Worker<?> w : workers) {
                 results.getUnknown().putHistogram(w.getTransactionUnknownHistogram());
                 results.getSuccess().putHistogram(w.getTransactionSuccessHistogram());

--- a/src/main/java/com/oltpbenchmark/ThreadBench.java
+++ b/src/main/java/com/oltpbenchmark/ThreadBench.java
@@ -329,7 +329,6 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
             results.getError().putAll(txnTypes, 0);
             results.getRetryDifferent().putAll(txnTypes, 0);
             results.getZeroRows().putAll(txnTypes, 0);
-
             for (Worker<?> w : workers) {
                 results.getUnknown().putHistogram(w.getTransactionUnknownHistogram());
                 results.getSuccess().putHistogram(w.getTransactionSuccessHistogram());
@@ -339,6 +338,12 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                 results.getRetryDifferent().putHistogram(w.getTransactionRetryDifferentHistogram());
                 results.getZeroRows().putHistogram(w.getTransactionZeroRowsHistogram());
                 results.getFeaturebenchAdditionalResults().setJsonResultsList(w.featurebenchAdditionalResults.getJsonResultsList());
+                /*int currentLength = w.featurebenchAdditionalResults.getJsonResultsList().size();
+                int length = 0;
+                if(currentLength > length) {
+                    length = currentLength;
+                    results.getFeaturebenchAdditionalResults().setJsonResultsList(w.featurebenchAdditionalResults.getJsonResultsList());
+                }*/
             }
 
             return (results);

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -58,6 +58,8 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
 
     public AtomicBoolean isPGStatStatementCollected = new AtomicBoolean(false);
 
+    public AtomicBoolean isPGStatResetCalled = new AtomicBoolean(false);
+
     static AtomicBoolean isInitializeDone = new AtomicBoolean(false);
 
     public FeatureBenchWorker(FeatureBenchBenchmark benchmarkModule,
@@ -97,13 +99,17 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         if (isInitializeDone.get()) return;
         synchronized (FeatureBenchWorker.class) {
             if (isInitializeDone.get()) return;
-            if (this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)) {
+            if (
+                this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)
+                && !isPGStatResetCalled.get()
+            ) {
                 LOG.info("Resetting pg_stat_statements for workload : " + this.workloadName);
                 try {
                     Statement stmt = conn.createStatement();
                     stmt.executeQuery("SELECT pg_stat_statements_reset();");
                     if (!conn.getAutoCommit())
                         conn.commit();
+                    isPGStatResetCalled.set(true);
                 } catch (SQLException e) {
                     throw new RuntimeException(e);
                 }
@@ -297,27 +303,16 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                 List<JSONObject> jsonResultsList = new ArrayList<>();
                 JSONObject pgStatOutputs = null;
                 JSONObject pgPreparedStatementOutputs = null;
-                if (this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)) {
+                if (!isPGStatStatementCollected.get() && this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)) {
                     try {
                         LOG.info("Collecting pg_stat_statements for workload : " + this.workloadName);
                         pgStatOutputs = callPGStats();
+                        isPGStatStatementCollected.set(true);
                         /*TODO: remove collecting prepared_statements*/
                         pgPreparedStatementOutputs = collectPgPreparedStatements();
                     } catch (SQLException e) {
                         throw new RuntimeException(e);
                     }
-                }
-                // reset pg_stat_statements
-                try {
-                    if (this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)) {
-                        Statement stmt = null;
-                        stmt = conn.createStatement();
-                        stmt.executeQuery("SELECT pg_stat_statements_reset();");
-                    }
-                    if (!conn.getAutoCommit())
-                        conn.commit();
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
                 }
 
                 for (String queryString : queryStrings) {

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -99,9 +99,8 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         if (isInitializeDone.get()) return;
         synchronized (FeatureBenchWorker.class) {
             if (isInitializeDone.get()) return;
-            if (
+            if (!isPGStatResetCalled.get() &&
                 this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)
-                && !isPGStatResetCalled.get()
             ) {
                 LOG.info("Resetting pg_stat_statements for workload : " + this.workloadName);
                 try {


### PR DESCRIPTION
**Fixing issue:** Every thread in multithreaded featurebench run resets pg_stat_statement causing the results to be empty/not show the correct query.

**Fix:** removed unnecessary code from teardown method which was calling reset on pg_stat_statements. We do reset in initialise method which is enough.