### PR TITLE
Borealis workload-microbenchmark mapping on PG 

### DIFF
--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG10_pkey_index_hash_tbl_point_selects_data_cardinality_bigint.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG10_pkey_index_hash_tbl_point_selects_data_cardinality_bigint.yaml
@@ -79,6 +79,7 @@ microbenchmark:
         executeRules:
 
             - workload: INDG10_1_data_cardinality_hashtbl_point_lookup_index_scan_using_comp_skey_first_part_hash_1M
+              customTags: customer=2
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -93,6 +94,7 @@ microbenchmark:
                         - query: select * from pkeyBigint1M_1 where col_bigint_card2_1=1000498
 
             - workload: INDG10_4_data_cardinality_hashtbl_point_lookup_index_scan_using_comp_skey_sec_part_hash_1k_two_conditions
+              customTags: customer=1
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -100,6 +102,7 @@ microbenchmark:
                         - query: select * from pkeyBigint1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1=1000498
 
             - workload: INDG10_5_data_cardinality_hashtbl_point_lookup_index_scan_using_comp_skey_third_part_hash_100_two_conditions
+              customTags: customer=2
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG11_pkey_index_hash_tbl_point_selects_data_cardinality_varchar.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG11_pkey_index_hash_tbl_point_selects_data_cardinality_varchar.yaml
@@ -92,6 +92,7 @@ microbenchmark:
 
 
             - workload: INDG11_2_data_cardinality_hashtbl_point_lookup_index_scan_using_comp_skey_sec_part_hash_1k_two_conditions
+              customTags: customer=1
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG1_pkey_point_selects_hash_table_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG1_pkey_point_selects_hash_table_indexscan.yaml
@@ -68,6 +68,7 @@ microbenchmark:
         executeRules:
 
             - workload: INDG1_1_hashtbl_point_lookup_index_scan_using_comp_pkey_first_part_hash
+              customTags: customer=10
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG2_pkey_point_selects_range_table_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG2_pkey_point_selects_range_table_indexscan.yaml
@@ -68,6 +68,7 @@ microbenchmark:
 
 
             - workload: INDG2_1_rangetbl_point_lookup_index_scan_using_comp_pkey_first_part_range
+              customTags: customer=7
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG5_sec_index_hash_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG5_sec_index_hash_tbl_point_selects_indexscan.yaml
@@ -65,6 +65,7 @@ microbenchmark:
         executeRules:
 
             - workload: INDG5_1_hashtbl_point_lookup_index_scan_using_comp_skey_first_part_hash
+              customTags: customer=9
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -79,6 +80,7 @@ microbenchmark:
                         - query: select * from Hashtbl_comp_skey_1 where col_bigint_id_3=500009
 
             - workload: INDG5_3_hashtbl_point_lookup_index_scan_using_mixed_comp_skey_first_part_hash
+              customTags: customer=1
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -65,6 +65,7 @@ microbenchmark:
 
 
             - workload: INDG6_1_rangetbl_point_lookup_index_scan_using_comp_range_skey_first_part_range
+              customTags: customer=1
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -79,6 +80,7 @@ microbenchmark:
                         - query: select * from Rangetbl_1 where col_bigint_id_4=500009
 
             - workload: INDG6_3_rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
+              customTags: customer=5
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100

--- a/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG3_projection_datatype_impact.yaml
+++ b/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG3_projection_datatype_impact.yaml
@@ -86,12 +86,14 @@ microbenchmark:
                     queries:
                         - query: select count(col_bigint_id_2) from Indexed1M_1
             - workload: AGGRG3_count_on_indexed_float
+              customTags: customer=1
               run:
                   - name: pg_count_on_indexed_varchar10
                     weight: 100
                     queries:
                         - query: select count(col_float5_1) from Indexed1M_1
             - workload: AGGRG3_count_on_indexed_varchar10
+              customTags: customer=1
               run:
                   - name: pg_count_on_indexed_varchar10
                     weight: 100

--- a/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG4_impact_of_distinct_on_increasing_row.yaml
+++ b/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG4_impact_of_distinct_on_increasing_row.yaml
@@ -143,6 +143,7 @@ microbenchmark:
                       params: [1, 500]
         executeRules:
             - workload: AGGRG4_distinct_bigint_1L_table_rows
+              customTags: customer=1
               run:
                   - name: pg_distinct_bigint_non_indexed_column
                     weight: 100
@@ -155,6 +156,7 @@ microbenchmark:
                     queries:
                         - query: select distinct(col_bigint_id_1) from pkeyBigint1M_1
             - workload: AGGRG4_distinct_bigint_10M_table_rows
+              customTags: customer=2
               run:
                   - name: pg_distinct_bigint_10M_table_rows
                     weight: 100

--- a/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG5_impact_of_max_on_increasing_row.yaml
+++ b/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG5_impact_of_max_on_increasing_row.yaml
@@ -143,6 +143,7 @@ microbenchmark:
                       params: [1, 500]
         executeRules:
             - workload: AGGRG5_max_bigint_1L_table_rows
+              customTags: customer=2
               run:
                   - name: pg_distinct_bigint_non_indexed_column
                     weight: 100

--- a/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG6_impact_of_sum_on_increasing_row.yaml
+++ b/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG6_impact_of_sum_on_increasing_row.yaml
@@ -155,6 +155,7 @@ microbenchmark:
                     queries:
                         - query: select sum(col_bigint_id_1) from pkeyBigint1M_1
             - workload: AGGRG6_sum_bigint_10M_table_rows
+              customTags: customer=2
               run:
                   - name: pg_distinct_bigint_10M_table_rows
                     weight: 100

--- a/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG7_filter_condition_index_type_impact.yaml
+++ b/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG7_filter_condition_index_type_impact.yaml
@@ -72,18 +72,21 @@ microbenchmark:
 
         executeRules:
             - workload: AGGRG7_count_bigint_non_indexed_column_with_filter_condition
+              customTags: customer=2
               run:
                   - name: yb_count_bigint_non_indexed_column_with_filter_condition
                     weight: 100
                     queries:
                         - query: select count(col_bigint_id_3) from Indexed1M_1 where col_bigint_id_3>1
             - workload: AGGRG7_count_bigint_pkey_column_with_filter_condition
+              customTags: customer=2
               run:
                   - name: yb_count_bigint_non_indexed_column_with_filter_condition
                     weight: 100
                     queries:
                         - query: select count(col_bigint_id_1) from Indexed1M_1 where col_bigint_id_1>1
             - workload: AGGRG7_count_bigint_secondary_indexed_column_with_filter_condition
+              customTags: customer=2
               run:
                   - name: yb_count_bigint_non_indexed_column_with_filter_condition
                     weight: 100

--- a/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG9_aggregates_on_hash_partitioned_table.yaml
+++ b/config/yugabyte/regression_pipelines/aggregate_workloads/postgres/AGGRG9_aggregates_on_hash_partitioned_table.yaml
@@ -104,12 +104,14 @@ microbenchmark:
                     queries:
                         - query: select count(col_bigint_id_2) from Indexed1M_1 where col_bigint_id_2>1
             -   workload: AGGRG9_count_bigint_range_secondary_indexed_column
+                customTags: customer=1
                 run:
                     -   name: count_bigint_non_indexed_column
                         weight: 100
                         queries:
                             -   query: select count(col_bigint_id_4) from Indexed1M_1
             -   workload: AGGRG9_count_bigint_range_secondary_indexed_column_with_filter
+                customTags: customer=1
                 run:
                     -   name: count_bigint_non_indexed_column
                         weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING1_join_on_hash_partitioned_tbl.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING1_join_on_hash_partitioned_tbl.yaml
@@ -71,6 +71,7 @@ microbenchmark:
 
         executeRules:
             - workload: JOING1_1_join_on_pk_of_hash_tbl
+              customTags: customer=2
               run:
                   - name: join_on_pk_of_hash_tbl
                     weight: 100
@@ -85,6 +86,7 @@ microbenchmark:
                         - query: select Hashtbl_1.col_bigint_id_1,Hashtbl_2.col_bigint_id_1 from Hashtbl_1 join Hashtbl_2 on Hashtbl_1.col_bigint_id_1=Hashtbl_2.col_bigint_id_1 where Hashtbl_1.col_bigint_id_1<100001
 
             - workload: JOING1_3_join_on_pk_of_hash_tbl_with_2_filter
+              customTags: customer=1
               run:
                   - name: join_on_pk_of_hash_tbl
                     weight: 100
@@ -113,6 +115,7 @@ microbenchmark:
                             -   query: select Hashtbl_1.col_bigint_id_3,Hashtbl_2.col_bigint_id_3 from Hashtbl_1 join Hashtbl_2 on Hashtbl_1.col_bigint_id_3=Hashtbl_2.col_bigint_id_3
 
             -   workload: JOING1_7_join_on_rangeidx_of_hash_tbl_with_1_filter
+                customTags: customer=3
                 run:
                     -   name: join_on_pk_of_hash_tbl
                         weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING2_join_on_range_partitioned_tbl.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING2_join_on_range_partitioned_tbl.yaml
@@ -76,6 +76,7 @@ microbenchmark:
                         - query: select Rangetbl_1.col_bigint_id_1,Rangetbl_2.col_bigint_id_1 from Rangetbl_1 join Rangetbl_2 on Rangetbl_1.col_bigint_id_1=Rangetbl_2.col_bigint_id_1
 
             - workload: JOING2_2_join_on_pk_of_range_tbl_with_1_filter
+              customTags: customer=1
               run:
                   - name: join_on_pk_of_range_tbl
                     weight: 100
@@ -83,6 +84,7 @@ microbenchmark:
                         - query: select Rangetbl_1.col_bigint_id_1,Rangetbl_2.col_bigint_id_1 from Rangetbl_1 join Rangetbl_2 on Rangetbl_1.col_bigint_id_1=Rangetbl_2.col_bigint_id_1 where Rangetbl_1.col_bigint_id_1<100001
 
             - workload: JOING2_3_join_on_pk_of_range_tbl_with_2_filter
+              customTags: customer=2
               run:
                   - name: join_on_pk_of_range_tbl
                     weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING3_join_predicate_cases.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING3_join_predicate_cases.yaml
@@ -116,6 +116,7 @@ microbenchmark:
 
         executeRules:
             - workload: JOING3_1_join_on_pk_of_range_and_hash_tbl
+              customTags: customer=2
               run:
                   - name: join_on_pk_of_range_and_hash_tbl
                     weight: 100
@@ -124,6 +125,7 @@ microbenchmark:
 
 
             -   workload: JOING3_2_join_on_hashpk_IN_clause_1k
+                customTags: customer=6
                 run:
                     -   name: join_on_pk_of_range_and_hash_tbl
                         weight: 100
@@ -146,6 +148,7 @@ microbenchmark:
                                     params: [ 1, 1000000 ]
 
             -   workload: JOING3_4_join_on_rangepk_IN_clause_1k
+                customTags: customer=3
                 run:
                     -   name: join_on_pk_of_range_and_hash_tbl
                         weight: 100
@@ -168,6 +171,7 @@ microbenchmark:
                                     params: [ 1, 1000000 ]
 
             -   workload: JOING3_6_join_on_hashidx_IN_clause_10k
+                customTags: customer=1
                 run:
                     -   name: join_on_pk_of_range_and_hash_tbl
                         weight: 100
@@ -179,6 +183,7 @@ microbenchmark:
                                     params: [ 1, 1000000 ]
 
             -   workload: JOING3_7_join_on_rangeidx_IN_clause_10k
+                customTags: customer=2
                 run:
                     -   name: join_on_pk_of_range_and_hash_tbl
                         weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING4_datatype_impact_joins.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING4_datatype_impact_joins.yaml
@@ -157,6 +157,7 @@ microbenchmark:
 
 
             - workload: JOING4_2_join_on_pk_of_varchar_datatype
+              customTags: customer=1
               run:
                   - name: join_on_pk_of_bigint_datatype
                     weight: 100
@@ -164,6 +165,7 @@ microbenchmark:
                         - query: select pkeyVarchar1001M_1.col_varchar100_pid_1,pkeyVarchar1001M_2.col_varchar100_pid_1 from pkeyVarchar1001M_1 join pkeyVarchar1001M_2 on pkeyVarchar1001M_1.col_varchar100_pid_1=pkeyVarchar1001M_2.col_varchar100_pid_1
 
             -   workload: JOING4_3_join_on_pk_of_uuid_datatype
+                customTags: customer=1
                 run:
                     -   name: join_on_pk_of_bigint_datatype
                         weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING5_to_test_data_cardinality.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING5_to_test_data_cardinality.yaml
@@ -128,6 +128,7 @@ microbenchmark:
         executeRules:
 
             - workload: JoinG5_1_1Mtbl_join_1Mtbl_two_conditions_indexscan_two_filters
+              customTags: customer=3
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -142,6 +143,7 @@ microbenchmark:
                         - query: select * from pkeyBigint1M_1 as a join pkeyBigint1M_2 as b on a.col_bigint_card1_1=b.col_bigint_card1_1 and a.col_bigint_card2_1=b.col_bigint_card2_1 where b.col_bigint_card1_1=1000000 and  b.col_bigint_card3_1 in (1000058);
 
             - workload: JoinG5_3_1Mtbl_join_1Mtbl_two_conditions_indexscan_two_filters
+              customTags: customer=7
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -158,6 +160,7 @@ microbenchmark:
 
 
             -   workload: JoinG5_5_1Mtbl_join_10ktbl_two_conditions_indexscan_two_filters
+                customTags: customer=1
                 run:
                     -   name: hashtbl_index_scan_using_sec_index
                         weight: 100
@@ -165,6 +168,7 @@ microbenchmark:
                             -   query: select * from pkeyBigint1M_1 as a join pkeyBigint10k_1 as b on a.col_bigint_card1_1=b.col_bigint_card1_1 and a.col_bigint_card3_1=b.col_bigint_card3_1 where b.col_bigint_card1_1=1000000 and  b.col_bigint_card2_1 in (1000058);
 
             -   workload: JoinG5_6_1Mtbl_join_10ktbl_two_conditions_indexscan_two_filters
+                customTags: customer=3
                 run:
                     -   name: hashtbl_index_scan_using_sec_index
                         weight: 100
@@ -172,6 +176,7 @@ microbenchmark:
                             -   query: select * from pkeyBigint1M_1 as a join pkeyBigint10k_1 as b on a.col_bigint_card1_1=b.col_bigint_card1_1 and a.col_bigint_card2_1=b.col_bigint_card2_1 where b.col_bigint_card1_1=1000000 and  b.col_bigint_card3_1 in (1000058);
 
             -   workload: JoinG5_7_1Mtbl_join_10ktbl_two_conditions_indexscan_two_filters
+                customTags: customer=8
                 run:
                     -   name: hashtbl_index_scan_using_sec_index
                         weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING6_to_test_data_cardinality_skey.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING6_to_test_data_cardinality_skey.yaml
@@ -131,6 +131,7 @@ microbenchmark:
         executeRules:
 
             - workload: JoinG6_1_1Mtbl_join_1Mtbl_two_conditions_indexscan_two_filters
+              customTags: customer=3
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -145,6 +146,7 @@ microbenchmark:
                         - query: select * from pkeyBigint1M_1 as a join pkeyBigint1M_2 as b on a.col_bigint_card1_1=b.col_bigint_card1_1 and a.col_bigint_card2_1=b.col_bigint_card2_1 where b.col_bigint_card1_1=1000000 and  b.col_bigint_card3_1 in (1000058);
 
             - workload: JoinG6_3_1Mtbl_join_1Mtbl_two_conditions_indexscan_two_filters
+              customTags: customer=3
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
@@ -161,6 +163,7 @@ microbenchmark:
 
 
             -   workload: JoinG6_5_1Mtbl_join_10ktbl_two_conditions_indexscan_two_filters
+                customTags: customer=3
                 run:
                     -   name: hashtbl_index_scan_using_sec_index
                         weight: 100
@@ -175,6 +178,7 @@ microbenchmark:
                             -   query: select * from pkeyBigint1M_1 as a join pkeyBigint10k_1 as b on a.col_bigint_card1_1=b.col_bigint_card1_1 and a.col_bigint_card2_1=b.col_bigint_card2_1 where b.col_bigint_card1_1=1000000 and  b.col_bigint_card3_1 in (1000058);
 
             -   workload: JoinG6_7_1Mtbl_join_10ktbl_two_conditions_indexscan_two_filters
+                customTags: customer=3
                 run:
                     -   name: hashtbl_index_scan_using_sec_index
                         weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING7_pkey_rangescan_join.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING7_pkey_rangescan_join.yaml
@@ -78,18 +78,21 @@ microbenchmark:
                     queries:
                         - query: select pkey_rangescan_join_1.col_bigint_id_1 from pkey_rangescan_join_1 JOIN pkey_rangescan_join_2 on pkey_rangescan_join_1.col_bigint_id_1=pkey_rangescan_join_2.col_bigint_id_1 and pkey_rangescan_join_1.col_bigint_id_1<2;
             - workload: JoinG7_pkey_rangescan_join_fetch_10row
+              customTags: customer=4
               run:
                   - name: pkey_rangescan_join_fetch_10row_test
                     weight: 100
                     queries:
                         - query: select pkey_rangescan_join_1.col_bigint_id_1 from pkey_rangescan_join_1 JOIN pkey_rangescan_join_2 on pkey_rangescan_join_1.col_bigint_id_1=pkey_rangescan_join_2.col_bigint_id_1 and pkey_rangescan_join_1.col_bigint_id_1<11;
             - workload: JoinG7_pkey_rangescan_join_fetch_1000row
+              customTags: customer=6
               run:
                   - name: pkey_rangescan_join_fetch_1000row_test
                     weight: 100
                     queries:
                         - query: select pkey_rangescan_join_1.col_bigint_id_1 from pkey_rangescan_join_1 JOIN pkey_rangescan_join_2 on pkey_rangescan_join_1.col_bigint_id_1=pkey_rangescan_join_2.col_bigint_id_1 and pkey_rangescan_join_1.col_bigint_id_1<1001;
             - workload: JoinG7_pkey_rangescan_join_fetch_100000row
+              customTags: customer=1
               run:
                   - name: pkey_rangescan_join_fetch_100000row_test
                     weight: 100

--- a/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING8_hash_merge_join.yaml
+++ b/config/yugabyte/regression_pipelines/join_workloads/postgres/JOING8_hash_merge_join.yaml
@@ -67,6 +67,7 @@ microbenchmark:
                         params: [ 500, 500 ]
         executeRules:
             -   workload: JoinG8_hash_join_fetch_1row
+                customTags: customer=1
                 run:
                     -   name: hash_join_fetch_1row
                         weight: 100
@@ -88,6 +89,7 @@ microbenchmark:
                             -   query: select pkey_rangescan_join_1.col_bigint_id_1 from pkey_rangescan_join_1 JOIN pkey_rangescan_join_2 on pkey_rangescan_join_1.col_bigint_id_1=pkey_rangescan_join_2.col_bigint_id_1 and pkey_rangescan_join_1.col_bigint_id_1 < 2  and pkey_rangescan_join_2.col_bigint_id_1 < 2;
 
             -   workload: JoinG8_merge_join_fetch_1000row
+                customTags: customer=4
                 run:
                     -   name: merge_join_fetch_1000row
                         weight: 100

--- a/config/yugabyte/regression_pipelines/orderby_workloads/postgres/ORDG1_index_type_impact.yaml
+++ b/config/yugabyte/regression_pipelines/orderby_workloads/postgres/ORDG1_index_type_impact.yaml
@@ -73,12 +73,14 @@ microbenchmark:
 
         executeRules:
             - workload: ORDG1_ordby_bigint_non_indexed_column
+              customTags: customer=2
               run:
                   - name: yb_ordby_bigint_non_indexed_column
                     weight: 100
                     queries:
                         - query: select col_bigint_id_3 from Indexed1M_1 order by col_bigint_id_3
             - workload: ORDG1_ordby_bigint_pkey_column
+              customTags: customer=2
               run:
                   - name: yb_ordby_bigint_non_indexed_column
                     weight: 100

--- a/config/yugabyte/regression_pipelines/orderby_workloads/postgres/ORDG5_impact_of_datatype_with_sec_ind_desc.yaml
+++ b/config/yugabyte/regression_pipelines/orderby_workloads/postgres/ORDG5_impact_of_datatype_with_sec_ind_desc.yaml
@@ -200,6 +200,7 @@ microbenchmark:
                         params: [ 1, 500 ]
         executeRules:
             -   workload: ORDG5_ordby_bigint_indexed_column_desc
+                customTags: customer=2
                 run:
                     -   name: ordby_bigint_indexed_column_desc
                         weight: 100

--- a/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG11_pkey_rangeScan_INclause_project_indexed_nonindexed_cols.yaml
+++ b/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG11_pkey_rangeScan_INclause_project_indexed_nonindexed_cols.yaml
@@ -90,6 +90,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG11_pkey_INclause_rangescan_increasing_rows_100row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_100row_test
                     weight: 100
@@ -100,6 +101,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG11_pkey_INclause_rangescan_increasing_rows_1000row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_1000row_test
                     weight: 100
@@ -110,6 +112,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG11_pkey_INclause_rangescan_increasing_rows_10000row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_10000row_test
                     weight: 100

--- a/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG12_bitmapscan_orCondition.yaml
+++ b/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG12_bitmapscan_orCondition.yaml
@@ -82,6 +82,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG12_bitmapscan_orCondition_100row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_100row_test
                     weight: 100
@@ -92,6 +93,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG12_bitmapscan_orCondition_1000row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_1000row_test
                     weight: 100
@@ -102,6 +104,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG12_bitmapscan_orCondition_10000row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_10000row_test
                     weight: 100

--- a/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG1_hash_pointlookup_primarykey_vs_index.yaml
+++ b/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG1_hash_pointlookup_primarykey_vs_index.yaml
@@ -106,12 +106,14 @@ microbenchmark:
                     params: [500, 500]
         executeRules:
             - workload: scanG1_pkey_hash_point_lookup
+              customTags: customer=8
               run:
                   - name: pkey_hash_point_lookup_test
                     weight: 100
                     queries:
                         - query: select col_bigint_id_1 from pkey_hash_point_lookup_tbl_1 where col_bigint_id_1=500009
             - workload: scanG1_indx_hash_point_lookup
+              customTags: customer=6
               run:
                   - name: indx_hash_point_lookup_test
                     weight: 100

--- a/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG4_pkey_rangeScan_INclause_increasingRows_.yaml
+++ b/config/yugabyte/regression_pipelines/scan_workloads/postgres/scanG4_pkey_rangeScan_INclause_increasingRows_.yaml
@@ -90,6 +90,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG4_pkey_INclause_rangescan_increasing_rows_100row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_100row_test
                     weight: 100
@@ -100,6 +101,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG4_pkey_INclause_rangescan_increasing_rows_1000row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_1000row_test
                     weight: 100
@@ -110,6 +112,7 @@ microbenchmark:
                               util: RandomNumber
                               params: [ 1, 1000000 ]
             - workload: scanG4_pkey_INclause_rangescan_increasing_rows_10000row
+              customTags: customer=1
               run:
                   - name: pkey_INclause_rangescan_increasing_rows_10000row_test
                     weight: 100


### PR DESCRIPTION
Added `customTags: customer` workload tags to the corresponding postgres yamls