### PR TITLE
Added new workloads to update 10k/50k rows to existing microbenchmark updateG1_varying_rows.yaml 

### DIFF
--- a/config/yugabyte/regression_pipelines/write_workloads/postgres/updateG1_varying_rows.yaml
+++ b/config/yugabyte/regression_pipelines/write_workloads/postgres/updateG1_varying_rows.yaml
@@ -21,13 +21,16 @@ microbenchmark:
             - drop table if exists update_test_table1;
             - drop table if exists update_test_table2;
             - drop table if exists update_test_table3;
+            - drop table if exists update_test_table4;
             - create table update_test_table1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id))
             - create table update_test_table2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id))
             - create table update_test_table3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id))
+            - create table update_test_table4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id))
         cleanup:
             - drop table if exists update_test_table1;
             - drop table if exists update_test_table2;
             - drop table if exists update_test_table3;
+            - drop table if exists update_test_table4;
         loadRules:
             - table: update_test_table
               count: 3
@@ -80,3 +83,34 @@ microbenchmark:
                           bindings:
                               - util: RandomAString
                                 params: [20, 20]
+
+
+            - workload: update_10000
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table1 set col_int_1 = ? where id < 10001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]
+
+            - workload: update_50000
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table2 set col_int_1 = ? where id < 50001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]
+
+            - workload: update_50000_hash_table
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table4 set col_int_1 = ? where id < 50001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]

--- a/config/yugabyte/regression_pipelines/write_workloads/yb_colocated/updateG1_varying_rows.yaml
+++ b/config/yugabyte/regression_pipelines/write_workloads/yb_colocated/updateG1_varying_rows.yaml
@@ -24,16 +24,19 @@ microbenchmark:
             - drop table if exists update_test_table1;
             - drop table if exists update_test_table2;
             - drop table if exists update_test_table3;
+            - drop table if exists update_test_table4;
             - create table update_test_table1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
             - create table update_test_table2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
             - create table update_test_table3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table update_test_table4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id))
         cleanup:
             - drop table if exists update_test_table1;
             - drop table if exists update_test_table2;
             - drop table if exists update_test_table3;
+            - drop table if exists update_test_table4;
         loadRules:
             - table: update_test_table
-              count: 3
+              count: 4
               rows: 1000000
               columns:
                   - name: id
@@ -83,3 +86,34 @@ microbenchmark:
                           bindings:
                               - util: RandomAString
                                 params: [20, 20]
+
+
+            - workload: update_10000
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table1 set col_int_1 = ? where id < 10001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]
+
+            - workload: update_50000
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table2 set col_int_1 = ? where id < 50001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]
+
+            - workload: update_50000_hash_table
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table4 set col_int_1 = ? where id < 50001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]

--- a/config/yugabyte/regression_pipelines/write_workloads/yugabyte/updateG1_varying_rows.yaml
+++ b/config/yugabyte/regression_pipelines/write_workloads/yugabyte/updateG1_varying_rows.yaml
@@ -23,13 +23,16 @@ microbenchmark:
             - drop table if exists update_test_table1;
             - drop table if exists update_test_table2;
             - drop table if exists update_test_table3;
+            - drop table if exists update_test_table4;
             - create table update_test_table1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
             - create table update_test_table2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
             - create table update_test_table3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table update_test_table4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id))
         cleanup:
             - drop table if exists update_test_table1;
             - drop table if exists update_test_table2;
             - drop table if exists update_test_table3;
+            - drop table if exists update_test_table4;
         loadRules:
             - table: update_test_table
               count: 3
@@ -82,3 +85,34 @@ microbenchmark:
                           bindings:
                               - util: RandomAString
                                 params: [20, 20]
+
+
+            - workload: update_10000
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table1 set col_int_1 = ? where id < 10001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]
+
+            - workload: update_50000
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table2 set col_int_1 = ? where id < 50001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]
+
+            - workload: update_50000_hash_table
+              run:
+                  - name: update_1000_rows
+                    weight: 100
+                    queries:
+                        - query: UPDATE update_test_table4 set col_int_1 = ? where id < 50001
+                          bindings:
+                              -  util: RandomNumber
+                                 params: [ 1, 1000000 ]


### PR DESCRIPTION
Current microbenchmarks only updates max 1k rows. Considering the variations we have seen between test it is important to have tests with higher row count like 10-50k. As [mentioned](https://yugabyte.slack.com/archives/C027M2T0W8Z/p1731631938280839) by Mark Peacock, these scenarios are seen in production.

So wrote new microbenchmarks queries and triggered a validation runs on master and Yusong’s private build
https://perf.dev.yugabyte.com/dashboard/output/8468702
https://perf.dev.yugabyte.com/dashboard/output/8468602 