### PR TITLE
Explain plan for insert and other types of queries, with force_capture_explain_analyze flag support.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -135,13 +135,17 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
 
             String explainSelect = "explain (analyze,verbose,costs,buffers) ";
             String explainUpdate = "explain (analyze) ";
-            String explainOthers = "explain (debug, verbose, costs)";
+            String explainOthers = "explain ";
 
+            if (this.getWorkloadConfiguration().getXmlConfig().getBoolean("force_capture_explain_analyze", false)) {
+                explainOthers = "explain (analyze,verbose,costs,buffers) ";
+            }
             if (this.getWorkloadConfiguration().getXmlConfig().containsKey("use_dist_in_explain")
                 && this.getWorkloadConfiguration().getXmlConfig().getBoolean("use_dist_in_explain")) {
                 if (this.getWorkloadConfiguration().getXmlConfig().getString("type").equalsIgnoreCase("YUGABYTE")) {
-                    explainSelect = "explain (analyze,dist,verbose,costs,buffers,debug) ";
-                    explainUpdate = "explain (analyze, dist, debug) ";
+                    explainSelect = explainSelect.replace(") ", ",debug,dist) ");
+                    explainUpdate = explainUpdate.replace(") ", ",debug,dist) ");
+                    explainOthers = explainOthers.replace(") ", ",debug,dist) ");
                 } else {
                     throw new RuntimeException("dist and debug option for explain not supported by this database type, Please remove key!");
                 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -135,7 +135,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
 
             String explainSelect = "explain (analyze,verbose,costs,buffers) ";
             String explainUpdate = "explain (analyze) ";
-            String explainOthers = "explain ";
+            String explainOthers = "explain (debug, verbose, costs)";
 
             if (this.getWorkloadConfiguration().getXmlConfig().containsKey("use_dist_in_explain")
                 && this.getWorkloadConfiguration().getXmlConfig().getBoolean("use_dist_in_explain")) {

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -157,7 +157,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                             try {
 
                                 PreparedStatement stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : explainUpdate) + querystmt);
-                                stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : (query.isUpdateQuery() ? explainUpdate : explainOthers)) + querystmt);
+                                stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : query.isUpdateQuery() ? explainUpdate : explainOthers) + querystmt);
                                 List<UtilToMethod> baseUtils = query.getBaseUtils();
                                 for (int j = 0; j < baseUtils.size(); j++) {
                                     try {

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -155,9 +155,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                         if (query.isSelectQuery() || query.isUpdateQuery()) {
                             String querystmt = query.getQuery();
                             try {
-
-                                PreparedStatement stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : explainUpdate) + querystmt);
-                                stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : query.isUpdateQuery() ? explainUpdate : explainOthers) + querystmt);
+                                PreparedStatement stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : query.isUpdateQuery() ? explainUpdate : explainOthers) + querystmt);
                                 List<UtilToMethod> baseUtils = query.getBaseUtils();
                                 for (int j = 0; j < baseUtils.size(); j++) {
                                     try {

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -152,24 +152,22 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
             if (!this.getWorkloadConfiguration().getXmlConfig().getBoolean("disable_explain", false)) {
                 for (ExecuteRule er : executeRules) {
                     for (Query query : er.getQueries()) {
-                        if (query.isSelectQuery() || query.isUpdateQuery()) {
-                            String querystmt = query.getQuery();
-                            try {
-                                PreparedStatement stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : query.isUpdateQuery() ? explainUpdate : explainOthers) + querystmt);
-                                List<UtilToMethod> baseUtils = query.getBaseUtils();
-                                for (int j = 0; j < baseUtils.size(); j++) {
-                                    try {
-                                        stmt.setObject(j + 1, baseUtils.get(j).get());
-                                    } catch (SQLException | InvocationTargetException | IllegalAccessException |
-                                             ClassNotFoundException | NoSuchMethodException |
-                                             InstantiationException e) {
-                                        throw new RuntimeException(e);
-                                    }
+                        String querystmt = query.getQuery();
+                        try {
+                            PreparedStatement stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : query.isUpdateQuery() ? explainUpdate : explainOthers) + querystmt);
+                            List<UtilToMethod> baseUtils = query.getBaseUtils();
+                            for (int j = 0; j < baseUtils.size(); j++) {
+                                try {
+                                    stmt.setObject(j + 1, baseUtils.get(j).get());
+                                } catch (SQLException | InvocationTargetException | IllegalAccessException |
+                                         ClassNotFoundException | NoSuchMethodException |
+                                         InstantiationException e) {
+                                    throw new RuntimeException(e);
                                 }
-                                explainDDLMap.put(query.getQuery(), stmt);
-                            } catch (SQLException e) {
-                                throw new RuntimeException(e);
                             }
+                            explainDDLMap.put(query.getQuery(), stmt);
+                        } catch (SQLException e) {
+                            throw new RuntimeException(e);
                         }
 
                     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -135,6 +135,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
 
             String explainSelect = "explain (analyze,verbose,costs,buffers) ";
             String explainUpdate = "explain (analyze) ";
+            String explainOthers = "explain ";
 
             if (this.getWorkloadConfiguration().getXmlConfig().containsKey("use_dist_in_explain")
                 && this.getWorkloadConfiguration().getXmlConfig().getBoolean("use_dist_in_explain")) {
@@ -156,6 +157,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                             try {
 
                                 PreparedStatement stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : explainUpdate) + querystmt);
+                                stmt = conn.prepareStatement((query.isSelectQuery() ? explainSelect : (query.isUpdateQuery() ? explainUpdate : explainOthers)) + querystmt);
                                 List<UtilToMethod> baseUtils = query.getBaseUtils();
                                 for (int j = 0; j < baseUtils.size(); j++) {
                                     try {


### PR DESCRIPTION
We used to identify and capture explain plans for select and update queries. As per @shantanugupta-yb 's requirement, we should also provide an option to capture explain plan for insert queries as well. 

This change introduces a third category of queries -> others. Any queries which are not select or update are considered in this category. And, ```explain``` output will be captured for such other queries by default. 
Additionally, if you want to capture output of ```explain (analyze,verbose,costs,buffers) ```, you will need to add ```force_capture_explain_analyze: true``` in the input yaml. 
**NOTE:**  When explain analyze is run, values actually get inserted. Hence, user/yaml creator will have to take care of duplicate kv errors like ```duplicate key value violates unique constraint```