### PR TITLE
Add benchmark for range-based write workload

### DIFF
--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/insert_varying_composite_index.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/insert_varying_composite_index.yaml
@@ -1,0 +1,140 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true
+username: {{username}}
+password: {{password}}
+
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 60
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: false
+        create:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+            - create table index_test_1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create index index_test_2_idx1 on index_test_2(col_int_1 asc);
+            - create index index_test_3_idx1 on index_test_3(col_int_1 asc, col_int_2 asc);
+            - create index index_test_4_idx1 on index_test_4(col_int_1 asc, col_int_2 asc, col_int_3 asc, col_int_4 asc, col_int_5 asc);
+        cleanup:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+        loadRules:
+            -   table: index_test_
+                count: 4
+
+                rows: 1000000
+                columns:
+                    -   name: id
+                        util: PrimaryIntGen
+                        params:
+                            - 1
+                            - 1000000
+                    -   name: col_int_
+                        count: 10
+                        util: RandomNumber
+                        params:
+                            - 1
+                            - 1000000
+                    -   name: col_varchar_
+                        count: 3
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_date
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_boolean
+                        util: RandomBoolean
+        executeRules:
+            -   workload: 0_column_composite_index_test
+                run:
+                    -   name: Insert_0_column_composite_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_1 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+            -   workload: 1_column_composite_index_test
+                run:
+                    -   name: Insert_1_column_composite_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_2 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+            -   workload: 2_column_composite_index_test
+                run:
+                    -   name: Insert_column_composite_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_3 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+            -   workload: 5_column_composite_index_test
+                run:
+                    -   name: Insert_column_composite_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_4 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+

--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/insert_varying_index.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/insert_varying_index.yaml
@@ -1,0 +1,152 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true
+username: {{username}}
+password: {{password}}
+
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 60
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: false
+        create:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+            - create table index_test_1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create index index_test_2_idx1 on index_test_2(col_int_1 asc);
+            - create index index_test_3_idx1 on index_test_3(col_int_1 asc);
+            - create index index_test_3_idx2 on index_test_3(col_int_2 asc);
+            - create index index_test_3_idx3 on index_test_3(col_int_3 asc);
+            - create index index_test_3_idx4 on index_test_3(col_int_4 asc);
+            - create index index_test_3_idx5 on index_test_3(col_int_5 asc);
+            - create index index_test_4_idx1 on index_test_4(col_int_1 asc);
+            - create index index_test_4_idx2 on index_test_4(col_int_2 asc);
+            - create index index_test_4_idx3 on index_test_4(col_int_3 asc);
+            - create index index_test_4_idx4 on index_test_4(col_int_4 asc);
+            - create index index_test_4_idx5 on index_test_4(col_int_5 asc);
+            - create index index_test_4_idx6 on index_test_4(col_int_6 asc);
+            - create index index_test_4_idx7 on index_test_4(col_int_7 asc);
+            - create index index_test_4_idx8 on index_test_4(col_int_8 asc);
+            - create index index_test_4_idx9 on index_test_4(col_int_9 asc);
+            - create index index_test_4_idx10 on index_test_4(col_int_10 asc);
+        cleanup:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+        loadRules:
+            -   table: index_test_
+                count: 4
+                rows: 1000000
+                columns:
+                    -   name: id
+                        util: PrimaryIntGen
+                        params:
+                            - 1
+                            - 1000000
+                    -   name: col_int_
+                        count: 10
+                        util: RandomNumber
+                        params:
+                            - 1
+                            - 1000000
+                    -   name: col_varchar_
+                        count: 3
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_date
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_boolean
+                        util: RandomBoolean
+        executeRules:
+            -   workload: no_index
+                run:
+                    -   name: Insert_without_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_1 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+            -   workload: 1_index_test
+                run:
+                    -   name: Insert_with_1_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_2 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+            -   workload: 5_index_test
+                run:
+                    -   name: Insert_with_5_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_3 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+            -   workload: 10_index_test
+                run:
+                    -   name: Insert_with_10_index_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO index_test_4 (id, col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7, col_int_8, col_int_9, col_int_10, col_varchar_1, col_varchar_2, col_varchar_3, col_date, col_boolean) values (?, ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1000001, 100000000 ]
+                                    -   util: RandomAString
+                                        count: 4
+                                        params: [ 20, 20 ]
+                                    -   util: RandomBoolean
+

--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/insert_varying_pk_columns.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/insert_varying_pk_columns.yaml
@@ -1,0 +1,94 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true
+username: {{username}}
+password: {{password}}
+
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 60
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: false
+        create:
+            - drop table if exists table_test_1;
+            - drop table if exists table_test_2;
+            - drop table if exists table_test_3;
+            - drop table if exists table_test_4;
+            - create table table_test_1 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_int_7 bigint, primary key (col_int_1 asc));
+            - create table table_test_2 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_int_7 bigint, primary key (col_int_1 asc, col_int_2 asc));
+            - create table table_test_3 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_int_7 bigint, primary key (col_int_1 asc, col_int_2 asc, col_int_3 asc));
+            - create table table_test_4 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_int_7 bigint, primary key (col_int_1 asc, col_int_2 asc, col_int_3 asc, col_int_4 asc, col_int_5 asc));
+
+        cleanup:
+            - drop table if exists table_test_1;
+            - drop table if exists table_test_2;
+            - drop table if exists table_test_3;
+            - drop table if exists table_test_4;
+        loadRules:
+            -   table: table_test_
+                count: 4
+                rows: 1000000
+                columns:
+                    -   name: col_int_
+                        count: 7
+                        util: PrimaryIntGen
+                        params:
+                            - 1
+                            - 1000000
+        executeRules:
+            -   workload: 1_range_column_test
+                run:
+                    -   name: Insert_1_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO table_test_1 (col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7) values (?, ?,?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        count: 7
+                                        params: [ 1000001, 100000000 ]
+            -   workload: 2_range_column_test
+                run:
+                    -   name: Insert_2_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO table_test_2 (col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7) values (?,?, ?,?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        count: 7
+                                        params: [ 1000001, 100000000 ]
+            -   workload: 3_range_column_test
+                run:
+                    -   name: Insert_3_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO table_test_3 (col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7) values (?,?,?, ?,?,?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        count: 7
+                                        params: [ 1000001, 100000000 ]
+            -   workload: 5_range_column_test
+                run:
+                    -   name: Insert_5_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: INSERT INTO table_test_4 (col_int_1, col_int_2, col_int_3, col_int_4, col_int_5, col_int_6, col_int_7) values (?,?,?,?,?, ?,?)
+                                count: 10
+                                bindings:
+                                    -   util: PrimaryIntGen
+                                        count: 7
+                                        params: [ 1000001, 100000000 ]

--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/multi_statement_transaction.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/multi_statement_transaction.yaml
@@ -1,0 +1,144 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true&load-balance=false
+username: {{username}}
+password: {{password}}
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 30
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: true
+        create:
+            - DROP TABLE IF EXISTS users_1;
+            - DROP TABLE IF EXISTS accounts_1;
+            - DROP TABLE IF EXISTS audit_table_1;
+            - CREATE TABLE IF NOT EXISTS users_1(user_id_1 bigint, user_id_2 bigint, user_name_1 varchar(10), addr_1 varchar(50), bal_1 float(2), PRIMARY KEY(user_id_1 ASC, user_id_2 ASC));
+            - CREATE INDEX users_1_index_user_name ON users_1(user_name_1 ASC, addr_1 ASC);
+            - CREATE INDEX users_1_index_addr ON users_1(addr_1 ASC, user_name_1 ASC);
+            - CREATE TABLE IF NOT EXISTS accounts_1(account_id_1 bigint, account_id_2 bigint, user_id_1 bigint, user_id_2 bigint, addr_1 varchar(50), bal_1 float(2), PRIMARY KEY(account_id_1 ASC, account_id_2 ASC));
+            - CREATE INDEX user_accounts_addr1 ON accounts_1( user_id_1 ASC, user_id_2 ASC, addr_1 ASC);
+            - CREATE INDEX user_accounts_addr2 ON accounts_1( addr_1 ASC, user_id_1 ASC, user_id_2 ASC);
+            - CREATE TABLE IF NOT EXISTS audit_table_1(account_id_1 bigint, account_id_2 bigint, event_id_1 date, user_id_1 bigint, user_id_2 bigint, delta_1 float(2), PRIMARY KEY(account_id_1 ASC, account_id_2 ASC, event_id_1 ASC));
+            - CREATE INDEX audit_table_1_index1 ON audit_table_1(user_id_1 ASC, user_id_2 ASC, event_id_1 ASC);
+            - CREATE INDEX audit_table_1_index2 ON audit_table_1(event_id_1 ASC, user_id_1 ASC, user_id_2 ASC);
+        cleanup:
+            - DROP TABLE IF EXISTS users_1;
+            - DROP TABLE IF EXISTS accounts_1;
+            - DROP TABLE IF EXISTS audit_table_1;
+
+        loadRules:
+            -   table: users_
+                count: 1
+                rows: 3000000
+                columns:
+                    -   name: user_id_
+                        count: 2
+                        util: PrimaryIntGen
+                        params: [ 1, 3000000 ]
+                    -   name: user_name_
+                        count: 1
+                        util: PrimaryStringGen
+                        params: [ 1, 10 ]
+                    -   name: addr_
+                        count: 1
+                        util: PrimaryStringGen
+                        params: [ 1, 50 ]
+                    -   name: bal_
+                        count: 1
+                        util: RandomNoWithDecimalPoints
+                        params: [ 1, 1000000, 2 ]
+
+            -   table: accounts_
+                count: 1
+                rows: 3000000
+                columns:
+                    -   name: account_id_
+                        count: 2
+                        util: PrimaryIntGen
+                        params: [ 1, 3000000 ]
+                    -   name: user_id_
+                        count: 2
+                        util: PrimaryIntGen
+                        params: [ 1, 3000000 ]
+                    -   name: addr_
+                        count: 1
+                        util: PrimaryStringGen
+                        params: [ 1, 50 ]
+                    -   name: bal_
+                        count: 1
+                        util: RandomNoWithDecimalPoints
+                        params: [ 1, 1000000, 2 ]
+
+            -   table: audit_table_
+                count: 1
+                rows: 3000000
+                columns:
+                    -   name: account_id_
+                        count: 2
+                        util: PrimaryIntGen
+                        params: [ 1, 3000000 ]
+                    -   name: event_id_
+                        count: 1
+                        util: PrimaryDateGen
+                        params: [2000000]
+                    -   name: user_id_
+                        count: 2
+                        util: PrimaryIntGen
+                        params: [ 1, 3000000 ]
+                    -   name: delta_
+                        count: 1
+                        util: RandomNoWithDecimalPoints
+                        params: [ 1, 1000000, 2 ]
+
+
+        executeRules:
+            - workload: MG2_1_multi_statement_transaction_run1
+              customTags: customer=10,schematype=regular,partition=hash,pkey=composite,cardinality=single,projection=all,filtercount=one,filteron=hashpkey,filtertype=pointselect,queryshape=scan
+              run:
+                  - name: statement1_insert
+                    weight: 100
+                    queries:
+                        - query: INSERT INTO audit_table_1(account_id_1, account_id_2, event_id_1, user_id_1, user_id_2, delta_1) VALUES(?,?,?,?,?,?)
+                          count: 10
+                          bindings:
+                              -   util: PrimaryIntGen
+                                  count: 2
+                                  params: [ 10000000, 10000000000 ]
+                              -   util: PrimaryDateGen
+                                  params: [ 100000000 ]
+                              -   util: PrimaryIntGen
+                                  count: 2
+                                  params: [ 10000000, 10000000000 ]
+                              -   util: RandomNoWithDecimalPoints
+                                  params: [ 1, 1000000, 2 ]
+                        - query: UPDATE accounts_1 SET addr_1 = ? WHERE account_id_1 = ? and account_id_2 = ? and user_id_1 = ? and user_id_2 = ?
+                          bindings:
+                              -   util: PrimaryStringGen
+                                  params: [ 1, 50 ]
+                              -   util: RandomInt
+                                  count: 2
+                                  params: [ 1, 3000000 ]
+                              -   util: RandomInt
+                                  count: 2
+                                  params: [ 1, 3000000 ]
+                        - query: UPDATE users_1 SET user_name_1 = ?, addr_1 = ? WHERE user_id_1 = ? and user_id_2 = ?
+                          bindings:
+                              -   util: PrimaryStringGen
+                                  params: [ 1, 10 ]
+                              -   util: PrimaryStringGen
+                                  params: [ 1, 50 ]
+                              -   util: RandomInt
+                                  count: 2
+                                  params: [ 1, 3000000 ]

--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/update_varying_composite_index.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/update_varying_composite_index.yaml
@@ -1,0 +1,116 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true&load-balance=false
+username: {{username}}
+password: {{password}}
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 60
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: false
+        create:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+            - create table index_test_1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create index index_test_2_idx1 on index_test_2(col_int_1 asc);
+            - create index index_test_3_idx1 on index_test_3(col_int_1 asc, col_int_2 asc);
+            - create index index_test_4_idx1 on index_test_4(col_int_1 asc, col_int_2 asc, col_int_3 asc, col_int_4 asc, col_int_5 asc);
+        cleanup:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+        loadRules:
+            -   table: index_test_
+                count: 4
+
+                rows: 2000000
+                columns:
+                    -   name: id
+                        util: PrimaryIntGen
+                        params:
+                            - 1
+                            - 2000000
+                    -   name: col_int_
+                        count: 10
+                        util: RandomNumber
+                        params:
+                            - 1
+                            - 2000000
+                    -   name: col_varchar_
+                        count: 3
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_date
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_boolean
+                        util: RandomBoolean
+        executeRules:
+            -   workload: 0_column_composite_index_test
+                run:
+                    -   name: Update_0_column_composite_index_test
+                        weight: 100
+                        queries:
+                             -   query: UPDATE index_test_1 SET col_int_1 = ? where id = ?
+                                 bindings:
+                                     -   util: RandomNumber
+                                         params: [ 1, 2000000 ]
+                                     -   util: RandomNumber
+                                         params: [ 1, 2000000 ]
+            -   workload: 1_column_composite_index_test
+                run:
+                    -   name: Update_1_column_composite_index_test
+                        weight: 100
+                        queries:
+                             -   query: UPDATE index_test_2 SET col_int_1 = ? where id = ?
+                                 bindings:
+                                     -   util: RandomNumber
+                                         params: [ 1, 2000000 ]
+                                     -   util: RandomNumber
+                                         params: [ 1, 2000000 ]
+            -   workload: 2_column_composite_index_test
+                run:
+                    -   name: Update_column_composite_index_test
+                        weight: 100
+                        queries:
+                             -   query: UPDATE index_test_3 SET col_int_1 = ?, col_int_2 = ? where id = ?
+                                 bindings:
+                                     -   util: RandomNumber
+                                         count: 2
+                                         params: [ 1, 2000000 ]
+                                     -   util: RandomNumber
+                                         params: [ 1, 2000000 ]
+            -   workload: 5_column_composite_index_test
+                run:
+                    -   name: Update_column_composite_index_test
+                        weight: 100
+                        queries:
+                              -   query: UPDATE index_test_4 SET col_int_1 = ?, col_int_2 = ?, col_int_3 = ?, col_int_4 = ?, col_int_5 = ? where id = ?
+                                  bindings:
+                                      -   util: RandomNumber
+                                          count: 5
+                                          params: [ 1, 2000000 ]
+                                      -   util: RandomNumber
+                                          params: [ 1, 2000000 ]

--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/update_varying_index.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/update_varying_index.yaml
@@ -1,0 +1,133 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true&load-balance=false
+username: {{username}}
+password: {{password}}
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 60
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: false
+        create:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+            - create table index_test_1 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_2 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_3 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create table index_test_4 (id bigint, col_int_1 int, col_int_2 int, col_int_3 int, col_int_4 int, col_int_5 int, col_int_6 int, col_int_7 int, col_int_8 int, col_int_9 int, col_int_10 int, col_varchar_1 varchar(20), col_varchar_2 varchar(20), col_varchar_3 varchar(20), col_date text, col_boolean boolean, primary key (id asc))
+            - create index index_test_2_idx1 on index_test_2(col_int_1 asc);
+            - create index index_test_3_idx1 on index_test_3(col_int_1 asc);
+            - create index index_test_3_idx2 on index_test_3(col_int_2 asc);
+            - create index index_test_3_idx3 on index_test_3(col_int_3 asc);
+            - create index index_test_3_idx4 on index_test_3(col_int_4 asc);
+            - create index index_test_3_idx5 on index_test_3(col_int_5 asc);
+            - create index index_test_4_idx1 on index_test_4(col_int_1 asc);
+            - create index index_test_4_idx2 on index_test_4(col_int_2 asc);
+            - create index index_test_4_idx3 on index_test_4(col_int_3 asc);
+            - create index index_test_4_idx4 on index_test_4(col_int_4 asc);
+            - create index index_test_4_idx5 on index_test_4(col_int_5 asc);
+            - create index index_test_4_idx6 on index_test_4(col_int_6 asc);
+            - create index index_test_4_idx7 on index_test_4(col_int_7 asc);
+            - create index index_test_4_idx8 on index_test_4(col_int_8 asc);
+            - create index index_test_4_idx9 on index_test_4(col_int_9 asc);
+            - create index index_test_4_idx10 on index_test_4(col_int_10 asc);
+        cleanup:
+            - drop table if exists index_test_1;
+            - drop table if exists index_test_2;
+            - drop table if exists index_test_3;
+            - drop table if exists index_test_4;
+        loadRules:
+            -   table: index_test_
+                count: 4
+                rows: 2000000
+                columns:
+                    -   name: id
+                        util: PrimaryIntGen
+                        params:
+                            - 1
+                            - 2000000
+                    -   name: col_int_
+                        count: 10
+                        util: RandomNumber
+                        params:
+                            - 1
+                            - 2000000
+                    -   name: col_varchar_
+                        count: 3
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_date
+                        util: RandomAString
+                        params:
+                            - 5
+                            - 5
+                    -   name: col_boolean
+                        util: RandomBoolean
+        executeRules:
+            -   workload: no_index
+                run:
+                    -   name: Update_without_index_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE index_test_1 SET col_int_1 = ? where id = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+            -   workload: 1_index_test
+                run:
+                    -   name: Update_with_1_index_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE index_test_2 SET col_int_1 = ? where id = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+            -   workload: 5_index_test
+                run:
+                    -   name: Update_with_5_index_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE index_test_3 SET col_int_1 = ?, col_int_2 = ?, col_int_3 = ?, col_int_4 = ?, col_int_5 = ? where id = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomNumber
+                                        count: 5
+                                        params: [ 1, 2000000 ]
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+            -   workload: 10_index_test
+                run:
+                    -   name: Update_with_10_index_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE index_test_4 SET col_int_1 = ?, col_int_2 = ?, col_int_3 = ?, col_int_4 = ?, col_int_5 = ?, col_int_6 = ?, col_int_7 = ?, col_int_8 = ?, col_int_9 = ?, col_int_10 = ? where id = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomNumber
+                                        count: 10
+                                        params: [ 1, 2000000 ]
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+

--- a/config/yugabyte/write_workloads/range_partition/yb_colocated/update_varying_pk_columns.yaml
+++ b/config/yugabyte/write_workloads/range_partition/yb_colocated/update_varying_pk_columns.yaml
@@ -1,0 +1,106 @@
+type: YUGABYTE
+driver: com.yugabyte.Driver
+url: jdbc:yugabytedb://{{endpoint}}:5433/yugabyte?sslmode=require&ApplicationName=featurebench&reWriteBatchedInserts=true&load-balance=false
+username: {{username}}
+password: {{password}}
+createdb: drop database if exists yb_colocated; create database yb_colocated with colocated=true
+batchsize: 128
+isolation: TRANSACTION_REPEATABLE_READ
+loaderthreads: 4
+terminals: 24
+collect_pg_stat_statements: true
+use_dist_in_explain : true
+yaml_version: v1.0
+works:
+    work:
+        time_secs: 300
+        rate: unlimited
+        warmup: 60
+microbenchmark:
+    class: com.oltpbenchmark.benchmarks.featurebench.customworkload.YBDefaultMicroBenchmark
+    properties:
+        setAutoCommit: false
+        create:
+            - drop table if exists table_test_1;
+            - drop table if exists table_test_2;
+            - drop table if exists table_test_3;
+            - drop table if exists table_test_4;
+            - create table table_test_1 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_varchar_1 varchar(20), primary key (col_int_1 asc));
+            - create table table_test_2 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_varchar_1 varchar(20), primary key (col_int_1 asc, col_int_2 asc));
+            - create table table_test_3 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_varchar_1 varchar(20), primary key (col_int_1 asc, col_int_2 asc, col_int_3 asc));
+            - create table table_test_4 (col_int_1 bigint, col_int_2 bigint, col_int_3 bigint, col_int_4 bigint, col_int_5 bigint, col_int_6 bigint, col_varchar_1 varchar(20), primary key (col_int_1 asc, col_int_2 asc, col_int_3 asc, col_int_4 asc, col_int_5 asc));
+
+        cleanup:
+            - drop table if exists table_test_1;
+            - drop table if exists table_test_2;
+            - drop table if exists table_test_3;
+            - drop table if exists table_test_4;
+        loadRules:
+            -   table: table_test_
+                count: 4
+                rows: 2000000
+                columns:
+                    -   name: col_int_
+                        count: 6
+                        util: PrimaryIntGen
+                        params:
+                            - 1
+                            - 2000000
+                    -   name: col_varchar_
+                        count: 1
+                        util: RandomAString
+                        params: [20, 20]
+
+        executeRules:
+            -   workload: 1_range_column_test
+                run:
+                    -   name: Update_1_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE table_test_1 SET col_varchar_1 = ? WHERE col_int_1 = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomAString
+                                        params: [20, 20]
+                                    -   util: RandomNumber
+                                        params: [ 1, 2000000 ]
+            -   workload: 2_range_column_test
+                run:
+                    -   name: Update_2_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE table_test_2 SET col_varchar_1 = ? WHERE col_int_1 = ? and col_int_2 = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomAString
+                                        params: [20, 20]
+                                    -   util: RandomNumber
+                                        count: 2
+                                        params: [ 1, 2000000 ]
+            -   workload: 3_range_column_test
+                run:
+                    -   name: Update_3_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE table_test_3 SET col_varchar_1 = ? WHERE col_int_1 = ? and col_int_2 = ? and col_int_3 = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomAString
+                                        params: [20, 20]
+                                    -   util: RandomNumber
+                                        count: 3
+                                        params: [ 1, 2000000 ]
+            -   workload: 5_range_column_test
+                run:
+                    -   name: Update_5_range_column_test
+                        weight: 100
+                        queries:
+                            -   query: UPDATE table_test_4 SET col_varchar_1 = ? WHERE col_int_1 = ? and col_int_2 = ? and col_int_3 = ? and col_int_4 = ? and col_int_5 = ?
+                                count: 1
+                                bindings:
+                                    -   util: RandomAString
+                                        params: [20, 20]
+                                    -   util: RandomNumber
+                                        count: 5
+                                        params: [ 1, 2000000 ]
+


### PR DESCRIPTION
The diff includes 7 write workloads:
INSERT
1. primary key (pk) has a varying number of range keys.
2. a varying number of range index
3. a varying number of composite range columns in the index.
 
UPDATE
1. primary key (pk) has a varying number of range keys.
2. a varying number of range index
3. a varying number of composite range columns in the index.

MULTI-STATEMENT
1. Include a combination of INSERT/UPDATE.