### PR TITLE
Index scan INDG6 | Renamed the columns of the existing index in PG to match the YB DDLs. 

### DIFF
--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -22,7 +22,7 @@ microbenchmark:
         create:
             - DROP TABLE IF EXISTS INDG6_U_Rangetbl_1;
             - CREATE TABLE INDG6_U_Rangetbl_1(col_bigint_id_1 bigint, col_bigint_id_2 bigint, col_bigint_id_3 bigint, col_bigint_id_4 bigint, col_bigint_id_5 bigint, col_bigint_id_6 bigint, col_float2_1 float(2), col_float2_2 float(2), col_float5_1 float(5), col_float5_2 float(5), col_boolean_1 boolean, col_varchar10_id_1 varchar(10), col_varchar100_id_1 varchar(100), col_varchar100_id_2 varchar(100), col_varchar500_id_1 varchar(500), PRIMARY KEY(col_bigint_id_1));
-            - CREATE INDEX ON INDG6_U_Rangetbl_1(col_bigint_id_3, col_bigint_id_4);
+            - CREATE INDEX ON INDG6_U_Rangetbl_1(col_bigint_id_2, col_bigint_id_3);
 
         cleanup:
             - DROP TABLE IF EXISTS INDG6_U_Rangetbl_1;
@@ -70,20 +70,13 @@ microbenchmark:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_3=500009
+                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_2=500009
 
             - workload: INDG6_2_iNDG6_U_Rangetbl_point_lookup_index_scan_using_comp_range_skey_sec_part_range
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_4=500009
+                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_3=500009
 
-            - workload: INDG6_3_iNDG6_U_Rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
-              customTags: customer=5
-              run:
-                  - name: hashtbl_index_scan_using_sec_index
-                    weight: 100
-                    queries:
-                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_3=500009 and col_bigint_id_4=500009
 

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -8,7 +8,7 @@ isolation: TRANSACTION_REPEATABLE_READ
 loaderthreads: 1
 terminals: 1
 collect_pg_stat_statements: true
-yaml_version: v1.0
+yaml_version: v2.0
 works:
     work:
         time_secs: 180

--- a/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/postgres/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -8,7 +8,7 @@ isolation: TRANSACTION_REPEATABLE_READ
 loaderthreads: 1
 terminals: 1
 collect_pg_stat_statements: true
-yaml_version: v1.0
+yaml_version: v2.0
 works:
     work:
         time_secs: 180
@@ -22,7 +22,7 @@ microbenchmark:
         create:
             - DROP TABLE IF EXISTS Rangetbl_1;
             - CREATE TABLE Rangetbl_1(col_bigint_id_1 bigint, col_bigint_id_2 bigint, col_bigint_id_3 bigint, col_bigint_id_4 bigint, col_bigint_id_5 bigint, col_bigint_id_6 bigint, col_float2_1 float(2), col_float2_2 float(2), col_float5_1 float(5), col_float5_2 float(5), col_boolean_1 boolean, col_varchar10_id_1 varchar(10), col_varchar100_id_1 varchar(100), col_varchar100_id_2 varchar(100), col_varchar500_id_1 varchar(500), PRIMARY KEY(col_bigint_id_1));
-            - CREATE INDEX ON Rangetbl_1(col_bigint_id_3, col_bigint_id_4);
+            - CREATE INDEX ON Rangetbl_1(col_bigint_id_2, col_bigint_id_3);
 
         cleanup:
             - DROP TABLE IF EXISTS Rangetbl_1;
@@ -70,20 +70,13 @@ microbenchmark:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from Rangetbl_1 where col_bigint_id_3=500009
+                        - query: select * from Rangetbl_1 where col_bigint_id_2=500009
 
             - workload: INDG6_2_rangetbl_point_lookup_index_scan_using_comp_range_skey_sec_part_range
               run:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from Rangetbl_1 where col_bigint_id_4=500009
+                        - query: select * from Rangetbl_1 where col_bigint_id_3=500009
 
-            - workload: INDG6_3_rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
-              customTags: customer=5
-              run:
-                  - name: hashtbl_index_scan_using_sec_index
-                    weight: 100
-                    queries:
-                        - query: select * from Rangetbl_1 where col_bigint_id_3=500009 and col_bigint_id_4=500009
 

--- a/config/yugabyte/regression_pipelines/Index_workloads/yb_colocated/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/yb_colocated/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -10,7 +10,7 @@ loaderthreads: 1
 terminals: 1
 collect_pg_stat_statements: true
 use_dist_in_explain : true
-yaml_version: v1.0
+yaml_version: v2.0
 works:
     work:
         time_secs: 180

--- a/config/yugabyte/regression_pipelines/Index_workloads/yb_colocated/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/yb_colocated/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -24,7 +24,7 @@ microbenchmark:
         create:
             - DROP TABLE IF EXISTS INDG6_U_Rangetbl_1;
             - CREATE TABLE INDG6_U_Rangetbl_1(col_bigint_id_1 bigint, col_bigint_id_2 bigint, col_bigint_id_3 bigint, col_bigint_id_4 bigint, col_bigint_id_5 bigint, col_bigint_id_6 bigint, col_float2_1 float(2), col_float2_2 float(2), col_float5_1 float(5), col_float5_2 float(5), col_boolean_1 boolean, col_varchar10_id_1 varchar(10), col_varchar100_id_1 varchar(100), col_varchar100_id_2 varchar(100), col_varchar500_id_1 varchar(500), PRIMARY KEY(col_bigint_id_1 ASC));
-            - CREATE INDEX ON INDG6_U_Rangetbl_1(col_bigint_id_3 ASC, col_bigint_id_4 ASC);
+            - CREATE INDEX ON INDG6_U_Rangetbl_1(col_bigint_id_2 ASC, col_bigint_id_3 ASC);
 
         cleanup:
             - DROP TABLE IF EXISTS INDG6_U_Rangetbl_1;
@@ -72,7 +72,7 @@ microbenchmark:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_3=500009
+                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_2=500009
 
             - workload: INDG6_2_INDG6_U_Rangetbl_point_lookup_index_scan_using_comp_range_skey_sec_part_range
               customTags: schematype=colocated,partition=range,skey=composite,cardinality=single,projection=all,filtercount=one,filteron=rangeskey,filtertype=pointselect,queryshape=scan
@@ -80,13 +80,6 @@ microbenchmark:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_4=500009
+                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_3=500009
 
-            - workload: INDG6_3_INDG6_U_Rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
-              customTags: customer=5,schematype=colocated,partition=range,skey=composite,cardinality=single,projection=all,filtercount=two,filteron=rangeskey,filtertype=pointselect,queryshape=scan
-              run:
-                  - name: hashtbl_index_scan_using_sec_index
-                    weight: 100
-                    queries:
-                        - query: select * from INDG6_U_Rangetbl_1 where col_bigint_id_3=500009 and col_bigint_id_4=500009
 

--- a/config/yugabyte/regression_pipelines/Index_workloads/yb_colocated/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/yb_colocated/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -10,7 +10,7 @@ loaderthreads: 1
 terminals: 1
 collect_pg_stat_statements: true
 use_dist_in_explain : true
-yaml_version: v1.0
+yaml_version: v2.0
 works:
     work:
         time_secs: 180
@@ -24,7 +24,7 @@ microbenchmark:
         create:
             - DROP TABLE IF EXISTS Rangetbl_1;
             - CREATE TABLE Rangetbl_1(col_bigint_id_1 bigint, col_bigint_id_2 bigint, col_bigint_id_3 bigint, col_bigint_id_4 bigint, col_bigint_id_5 bigint, col_bigint_id_6 bigint, col_float2_1 float(2), col_float2_2 float(2), col_float5_1 float(5), col_float5_2 float(5), col_boolean_1 boolean, col_varchar10_id_1 varchar(10), col_varchar100_id_1 varchar(100), col_varchar100_id_2 varchar(100), col_varchar500_id_1 varchar(500), PRIMARY KEY(col_bigint_id_1 ASC));
-            - CREATE INDEX ON Rangetbl_1(col_bigint_id_3 ASC, col_bigint_id_4 ASC);
+            - CREATE INDEX ON Rangetbl_1(col_bigint_id_2 ASC, col_bigint_id_3 ASC);
 
         cleanup:
             - DROP TABLE IF EXISTS Rangetbl_1;
@@ -72,7 +72,7 @@ microbenchmark:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from Rangetbl_1 where col_bigint_id_3=500009
+                        - query: select * from Rangetbl_1 where col_bigint_id_2=500009
 
             - workload: INDG6_2_rangetbl_point_lookup_index_scan_using_comp_range_skey_sec_part_range
               customTags: schematype=colocated,partition=range,skey=composite,cardinality=single,projection=all,filtercount=one,filteron=rangeskey,filtertype=pointselect,queryshape=scan
@@ -80,13 +80,6 @@ microbenchmark:
                   - name: hashtbl_index_scan_using_sec_index
                     weight: 100
                     queries:
-                        - query: select * from Rangetbl_1 where col_bigint_id_4=500009
+                        - query: select * from Rangetbl_1 where col_bigint_id_3=500009
 
-            - workload: INDG6_3_rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
-              customTags: customer=5,schematype=colocated,partition=range,skey=composite,cardinality=single,projection=all,filtercount=two,filteron=rangeskey,filtertype=pointselect,queryshape=scan
-              run:
-                  - name: hashtbl_index_scan_using_sec_index
-                    weight: 100
-                    queries:
-                        - query: select * from Rangetbl_1 where col_bigint_id_3=500009 and col_bigint_id_4=500009
 

--- a/config/yugabyte/regression_pipelines/Index_workloads/yugabyte/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/yugabyte/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -81,14 +81,6 @@ microbenchmark:
                     queries:
                         - query: select * from INDG6_U_Rangetbl_comp_skey_1 where col_bigint_id_3=500009
 
-            - workload: INDG6_3_rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
-              customTags: customer=5,schematype=regular,partition=range,skey=composite,cardinality=single,projection=all,filtercount=two,filteron=mixedskey,filtertype=pointselect,queryshape=scan
-              run:
-                  - name: hashtbl_index_scan_using_sec_index
-                    weight: 100
-                    queries:
-                        - query: select * from INDG6_U_Rangetbl_comp_skey_1 where col_bigint_id_3=500009 and col_bigint_id_4=500009
-
             - workload: INDG6_4_rangetbl_point_lookup_index_scan_using_mixed_comp_skey_first_part_hash
               customTags: customer=1,schematype=regular,partition=range,skey=composite,cardinality=single,projection=all,filtercount=one,filteron=hashskey,filtertype=pointselect,queryshape=scan
               run:

--- a/config/yugabyte/regression_pipelines/Index_workloads/yugabyte/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/yugabyte/INDG6_U_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -9,7 +9,7 @@ loaderthreads: 1
 terminals: 1
 collect_pg_stat_statements: true
 use_dist_in_explain : true
-yaml_version: v1.0
+yaml_version: v2.0
 works:
     work:
         time_secs: 180

--- a/config/yugabyte/regression_pipelines/Index_workloads/yugabyte/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
+++ b/config/yugabyte/regression_pipelines/Index_workloads/yugabyte/INDG6_sec_index_range_tbl_point_selects_indexscan.yaml
@@ -9,7 +9,7 @@ loaderthreads: 1
 terminals: 1
 collect_pg_stat_statements: true
 use_dist_in_explain : true
-yaml_version: v1.0
+yaml_version: v2.0
 works:
     work:
         time_secs: 180
@@ -81,13 +81,6 @@ microbenchmark:
                     queries:
                         - query: select * from Rangetbl_comp_skey_1 where col_bigint_id_3=500009
 
-            - workload: INDG6_3_rangetbl_point_lookup_index_scan_using_comp_skey_two_conditions_range
-              customTags: customer=5,schematype=regular,partition=range,skey=composite,cardinality=single,projection=all,filtercount=two,filteron=mixedskey,filtertype=pointselect,queryshape=scan
-              run:
-                  - name: hashtbl_index_scan_using_sec_index
-                    weight: 100
-                    queries:
-                        - query: select * from Rangetbl_comp_skey_1 where col_bigint_id_3=500009 and col_bigint_id_4=500009
 
             - workload: INDG6_4_rangetbl_point_lookup_index_scan_using_mixed_comp_skey_first_part_hash
               customTags: customer=1,schematype=regular,partition=range,skey=composite,cardinality=single,projection=all,filtercount=one,filteron=hashskey,filtertype=pointselect,queryshape=scan


### PR DESCRIPTION
I have renamed the columns of the existing index in PG to match the YB DDLs. 
Also removed a benchmark as with unordered the possibility of a row being return for that microbenchmark is almost nill.

Below is the PG comparison report, where new run is compared with existing PG run
https://perf.dev.yugabyte.com/report/view/W3sibmFtZSI6IlBHX29sZCIsImlzQmFzZWxpbmUiOnRydWUsInRlc3RfaWQiOiIxMjQwNjcwMiJ9LHsibmFtZSI6IlBHX3Bvc3RfY2hhbmdlIiwiaXNCYXNlbGluZSI6ZmFsc2UsInRlc3RfaWQiOiIxMjU5ODQwMiJ9XQ==