### PR TITLE
Fixed ug5_6 workload query filter

### DIFF
--- a/config/yugabyte/regression_pipelines/write_workloads/postgres/updateG5_update_included_colm.yaml
+++ b/config/yugabyte/regression_pipelines/write_workloads/postgres/updateG5_update_included_colm.yaml
@@ -8,7 +8,7 @@ isolation: TRANSACTION_REPEATABLE_READ
 loaderThreads: 1
 terminals: 1
 collect_pg_stat_statements: true
-yaml_version: v1.0
+yaml_version: v1.1
 works:
     work:
         time_secs: 180

--- a/config/yugabyte/regression_pipelines/write_workloads/yb_colocated/updateG5_update_included_colm.yaml
+++ b/config/yugabyte/regression_pipelines/write_workloads/yb_colocated/updateG5_update_included_colm.yaml
@@ -10,7 +10,7 @@ loaderThreads: 1
 terminals: 1
 collect_pg_stat_statements: true
 use_dist_in_explain : true
-yaml_version: v1.0
+yaml_version: v1.1
 works:
     work:
         time_secs: 180

--- a/config/yugabyte/regression_pipelines/write_workloads/yugabyte/updateG5_update_included_colm.yaml
+++ b/config/yugabyte/regression_pipelines/write_workloads/yugabyte/updateG5_update_included_colm.yaml
@@ -9,7 +9,7 @@ loaderThreads: 1
 terminals: 1
 collect_pg_stat_statements: true
 use_dist_in_explain : true
-yaml_version: v1.0
+yaml_version: v1.1
 works:
     work:
         time_secs: 180


### PR DESCRIPTION
Fixed the issues - The value(SET col_bigint_id_3=1000000) is getting updated in the UG5_4 workload, which is causing an foreign key constraint error in UG5_6. Below are the successful runs with the changes:
- [YB report](https://perf.dev.yugabyte.com/report/view/W3sibmFtZSI6ICJGZWF0dXJlYmVuY2ggV29ya2xvYWQiLCAidGVzdF9pZCI6ICIxMzMwMzgwMiIsICJpc0Jhc2VsaW5lIjogdHJ1ZX1d)
- [YB colocated report](https://perf.dev.yugabyte.com/report/view/W3sibmFtZSI6ICJGZWF0dXJlYmVuY2ggV29ya2xvYWQiLCAidGVzdF9pZCI6ICIxMzMwMzkwMiIsICJpc0Jhc2VsaW5lIjogdHJ1ZX1d#report-table)