### PR TITLE
Fix in Order by yaml

### DIFF
--- a/config/yugabyte/regression_pipelines/orderby_workloads/postgres/ORDG8_orderby_backwardscan_post_updates.yaml
+++ b/config/yugabyte/regression_pipelines/orderby_workloads/postgres/ORDG8_orderby_backwardscan_post_updates.yaml
@@ -235,7 +235,7 @@ microbenchmark:
                   - name: ordby_bckwrd_ind_scan_pkey_filter
                     weight: 100
                     queries:
-                        - query: select col_bigint_id_1,col_bigint_id_2,col_bigint_card2_1,col_bigint_card3_1 from Indexed1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1<1000100 order by col_bigint_car2_1 DESC
+                        - query: select col_bigint_id_1,col_bigint_id_2,col_bigint_card2_1,col_bigint_card3_1 from Indexed1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1<1000100 order by col_bigint_card2_1 DESC
 
             -   workload: ORDG8_2_post_update_ordby_bigint_indexed_column_desc
                 customTags: customer=2,schematype=regular,partition=range,skey=desc,columndatatype=bigint,cardinality=single,projection=indexed,queryshape=orderby,orderbyon=rangeskey

--- a/config/yugabyte/regression_pipelines/orderby_workloads/yb_colocated/ORDG8_orderby_backwardscan_post_updates.yaml
+++ b/config/yugabyte/regression_pipelines/orderby_workloads/yb_colocated/ORDG8_orderby_backwardscan_post_updates.yaml
@@ -237,7 +237,7 @@ microbenchmark:
                   - name: ordby_bckwrd_ind_scan_pkey_filter
                     weight: 100
                     queries:
-                        - query: select col_bigint_id_1,col_bigint_id_2,col_bigint_card2_1,col_bigint_card3_1 from Indexed1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1<1000100 order by col_bigint_car2_1 DESC
+                        - query: select col_bigint_id_1,col_bigint_id_2,col_bigint_card2_1,col_bigint_card3_1 from Indexed1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1<1000100 order by col_bigint_card2_1 DESC
 
             -   workload: ORDG8_2_post_update_ordby_bigint_indexed_column_desc
                 customTags: customer=2,schematype=regular,partition=range,skey=desc,columndatatype=bigint,cardinality=single,projection=indexed,queryshape=orderby,orderbyon=rangeskey

--- a/config/yugabyte/regression_pipelines/orderby_workloads/yugabyte/ORDG8_orderby_backwardscan_post_updates.yaml
+++ b/config/yugabyte/regression_pipelines/orderby_workloads/yugabyte/ORDG8_orderby_backwardscan_post_updates.yaml
@@ -236,7 +236,7 @@ microbenchmark:
                   - name: ordby_bckwrd_ind_scan_pkey_filter
                     weight: 100
                     queries:
-                        - query: select col_bigint_id_1,col_bigint_id_2,col_bigint_card2_1,col_bigint_card3_1 from Indexed1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1<1000100 order by col_bigint_car2_1 DESC
+                        - query: select col_bigint_id_1,col_bigint_id_2,col_bigint_card2_1,col_bigint_card3_1 from Indexed1M_1 where col_bigint_card1_1=1000000 and col_bigint_card2_1<1000100 order by col_bigint_card2_1 DESC
 
             -   workload: ORDG8_2_post_update_ordby_bigint_indexed_column_desc
                 customTags: customer=2,schematype=regular,partition=range,skey=desc,columndatatype=bigint,cardinality=single,projection=indexed,queryshape=orderby,orderbyon=rangeskey


### PR DESCRIPTION
- fixing typo in the column name for order by clause in workload ORDG8_1_post_update_ordby_bckwrd_ind_scan_pkey_filter