### PR TITLE
Adding workload specific Grafana Links

### DIFF
--- a/src/main/java/com/oltpbenchmark/Results.java
+++ b/src/main/java/com/oltpbenchmark/Results.java
@@ -33,6 +33,8 @@ public final class Results {
     private final int measuredRequests;
     private final DistributionStatistics distributionStatistics;
     private final List<LatencyRecord.Sample> latencySamples;
+    private long executionStartEpoch = -1;
+    private long executionEndEpoch = -1;
     private final Histogram<TransactionType> unknown = new Histogram<>(false);
     private final Histogram<TransactionType> success = new Histogram<>(true);
     private final Histogram<TransactionType> abort = new Histogram<>(false);
@@ -113,6 +115,22 @@ public final class Results {
 
     public int getMeasuredRequests() {
         return measuredRequests;
+    }
+
+    public long getExecutionStartEpoch() {
+        return executionStartEpoch;
+    }
+
+    public void setExecutionStartEpoch(long executionStartEpoch) {
+        this.executionStartEpoch = executionStartEpoch;
+    }
+
+    public long getExecutionEndEpoch() {
+        return executionEndEpoch;
+    }
+
+    public void setExecutionEndEpoch(long executionEndEpoch) {
+        this.executionEndEpoch = executionEndEpoch;
     }
 
     @Override

--- a/src/main/java/com/oltpbenchmark/ThreadBench.java
+++ b/src/main/java/com/oltpbenchmark/ThreadBench.java
@@ -117,6 +117,8 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
         long warmupStart = System.nanoTime();
         long warmup = warmupStart;
         long measureEnd = -1;
+        long executionStartEpoch = -1;
+        long executionEndEpoch = -1;
         // used to determine the longest sleep interval
         int lowestRate = Integer.MAX_VALUE;
 
@@ -228,6 +230,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                                 lastEntry = true;
                                 testState.startCoolDown();
                                 measureEnd = now;
+                                executionEndEpoch = System.currentTimeMillis();
                                 LOG.info("{} :: Waiting for all terminals to finish ..", StringUtil.bold("TERMINATE"));
                             } else if (phase != null) {
                                 // Reset serial execution parameters.
@@ -277,6 +280,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                     interruptWorkers();
                 }
                 start = now;
+                executionStartEpoch = System.currentTimeMillis();
                 LOG.info("{} :: Warmup complete, starting measurements.", StringUtil.bold("MEASURE"));
                 // measureEnd = measureStart + measureSeconds * 1000000000L;
 
@@ -327,6 +331,12 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
             }
 
             Results results = new Results(measureEnd - start, requests, stats, samples);
+            results.setExecutionStartEpoch(executionStartEpoch);
+            // If the measure phase end was never reached (e.g. early exit), fall back to "now".
+            if (executionEndEpoch < 0) {
+                executionEndEpoch = System.currentTimeMillis();
+            }
+            results.setExecutionEndEpoch(executionEndEpoch);
 
             // Compute transaction histogram
             Set<TransactionType> txnTypes = new HashSet<>();

--- a/src/main/java/com/oltpbenchmark/util/ResultWriter.java
+++ b/src/main/java/com/oltpbenchmark/util/ResultWriter.java
@@ -25,6 +25,7 @@ import com.oltpbenchmark.api.TransactionType;
 import com.oltpbenchmark.api.collectors.DBParameterCollector;
 import com.oltpbenchmark.api.collectors.DBParameterCollectorGen;
 import com.oltpbenchmark.types.DatabaseType;
+import org.json.JSONObject;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.configuration2.XMLConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
@@ -239,6 +240,12 @@ public class ResultWriter {
         metadata.put("yaml_version", expConf.getString("yaml_version", "v1.0"));
         metadata.put("customTags", formatCustomTags(customTags));
         metadata.put("skipReport",skipReport);
+        metadata.put("executionStartEpoch", results.getExecutionStartEpoch());
+        metadata.put("executionEndEpoch", results.getExecutionEndEpoch());
+        JSONObject additionalMetadata = results.getFeaturebenchAdditionalResults().getMetaDataJson();
+        for (String key : additionalMetadata.keySet()) {
+            metadata.put(key, additionalMetadata.get(key));
+        }
         detailedSummaryMap.put("metadata", metadata);
         detailedSummaryMap.put("Summary", summaryMap);
         detailedSummaryMap.put("queries", results.getFeaturebenchAdditionalResults().getJsonResultsList());


### PR DESCRIPTION
Adding workload specific execution start/end time to metadata to be used for workload specific Grafana Links.