### PR TITLE
Fixing build failure due to a missing method definition

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeaturebenchAdditionalResults.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeaturebenchAdditionalResults.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public class FeaturebenchAdditionalResults {
     List<JSONObject> jsonResultsList;
+    JSONObject metaDataJson = new JSONObject();
 
     public List<JSONObject> getJsonResultsList() {
         return jsonResultsList;
@@ -14,6 +15,14 @@ public class FeaturebenchAdditionalResults {
     public void setJsonResultsList(List<JSONObject> jsonResultsList) {
         this.jsonResultsList = jsonResultsList;
 
+    }
+
+    public JSONObject getMetaDataJson() {
+        return metaDataJson;
+    }
+
+    public void setMetaDataJson(JSONObject metaDataJson) {
+        this.metaDataJson = metaDataJson;
     }
 
 }


### PR DESCRIPTION
Fixing build failure due to a missing method `getMetaDataJson()` definition