### PR TITLE
Featurebench perf improvements

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchBenchmark.java
@@ -59,6 +59,10 @@ public class FeatureBenchBenchmark extends BenchmarkModule {
         List<HierarchicalConfiguration<ImmutableNode>> confExecuteRules = conf.configurationsAt("properties/executeRules[" + workcount + "]/run");
         String workloadName = conf.getString("properties/executeRules[" + workcount + "]/workload") != null ? conf.getString("properties/executeRules[" + workcount + "]/workload") : TimeUtil.getCurrentTimeString();
 
+        // Reset the shared per-workload state exactly once, before creating this
+        // workload's workers, so the "run once" init/teardown guards start clean.
+        FeatureBenchWorker.resetSharedState();
+
         for (int i = 0; i < workConf.getTerminals(); ++i) {
             FeatureBenchWorker worker = new FeatureBenchWorker(this, i,
                 conf.getString("class"),

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchLoader.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Statement;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
@@ -38,7 +39,12 @@ import java.util.*;
 
 public class FeatureBenchLoader extends Loader<FeatureBenchBenchmark> {
     private static final Logger LOG = LoggerFactory.getLogger(FeatureBenchLoader.class);
-    static int numberOfGeneratorFinished = 0;
+    // Incremented by each loader thread at the end of its load(), and read in afterLoad()
+    // (which the framework runs per thread, concurrently, in a finally block) to detect the
+    // last finisher that should trigger the afterLoad DDLs. Must be atomic: with a plain int,
+    // concurrent loader threads (loaderthreads > 1) lose increments, the counter never reaches
+    // sizeOfLoadRule, and the afterLoad phase silently never runs.
+    static AtomicInteger numberOfGeneratorFinished = new AtomicInteger(0);
     public String workloadClass = null;
     public HierarchicalConfiguration<ImmutableNode> config = null;
     public YBMicroBenchmark ybm = null;
@@ -228,7 +234,7 @@ public class FeatureBenchLoader extends Loader<FeatureBenchBenchmark> {
                 throw new RuntimeException(e);
             }
 
-            numberOfGeneratorFinished += 1;
+            numberOfGeneratorFinished.incrementAndGet();
         }
 
         private void typeCastDataTypes(StringBuilder valueString, int index) {
@@ -286,7 +292,7 @@ public class FeatureBenchLoader extends Loader<FeatureBenchBenchmark> {
 
         @Override
         public void afterLoad() {
-            if (numberOfGeneratorFinished != sizeOfLoadRule) return;
+            if (numberOfGeneratorFinished.get() != sizeOfLoadRule) return;
             afterLoadPhaseYaml();
         }
     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -60,7 +60,19 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
     private YBMicroBenchmark ybm;
     private final List<ExecuteRule> executeRules;
     private final String workloadName;
-    private HashMap<String, PreparedStatement> preparedStatementsPerQuery;
+    // The "execute" flag and whether any executeRules exist are constant for the life of a
+    // worker, so resolve them once here instead of re-parsing the HierarchicalConfiguration
+    // key path on every executeWork() call (the per-transaction hot loop). Both are per-worker
+    // final state, so this is safe at any terminal count.
+    private final boolean executeCustom;
+    private final boolean hasExecuteRules;
+    // Keyed by the Query object (identity semantics -- Query does not override equals/hashCode)
+    // rather than by the SQL text, so each lookup in the hot loop is an identity hash + reference
+    // compare instead of a full String.equals() over the (potentially very long) SQL. Each worker
+    // owns a distinct Query graph (see FeatureBenchBenchmark.configToExecuteRules, called per
+    // worker), and this map + its statements are bound to this worker's connection, so it stays
+    // private per worker.
+    private Map<Query, PreparedStatement> preparedStatementsPerQuery;
     public static Map<String,JSONObject> queryToExplainMap = new HashMap<>();
 
     static AtomicBoolean isInitializeDone = new AtomicBoolean(false);
@@ -85,6 +97,8 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         this.executeRules = executeRules;
         this.config = workerConfig;
         this.workloadName = workloadName;
+        this.executeCustom = config.containsKey("execute") && config.getBoolean("execute");
+        this.hasExecuteRules = executeRules != null && !executeRules.isEmpty();
         // NOTE: per-workload shared state is reset once in
         // FeatureBenchBenchmark.makeWorkersImpl (via resetSharedState()) before any
         // worker is constructed -- not here -- so the "run once" guards do not depend
@@ -114,12 +128,11 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
 
     protected void initialize() {
         try {
-            preparedStatementsPerQuery = new HashMap<>();
+            preparedStatementsPerQuery = new IdentityHashMap<>();
             for (ExecuteRule executeRule : executeRules) {
                 for (Query query : executeRule.getQueries()) {
-                    String queryStmt = query.getQuery();
-                    PreparedStatement stmt = conn.prepareStatement(queryStmt);
-                    preparedStatementsPerQuery.put(queryStmt, stmt);
+                    PreparedStatement stmt = conn.prepareStatement(query.getQuery());
+                    preparedStatementsPerQuery.put(query, stmt);
                 }
             }
         } catch (Exception e) {
@@ -390,10 +403,10 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
     protected TransactionStatus executeWork(Connection conn, TransactionType txnType) throws
         UserAbortException, SQLException {
         try {
-            if (config.containsKey("execute") && config.getBoolean("execute")) {
+            if (executeCustom) {
                 ybm.execute(conn);
                 return TransactionStatus.SUCCESS;
-            } else if (executeRules == null || executeRules.size() == 0) {
+            } else if (!hasExecuteRules) {
                 if (this.configuration.getWorkloadState().getGlobalState() == State.MEASURE) {
                     ybm.executeOnce(conn, this.getBenchmark());
                 }
@@ -404,8 +417,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
             ExecuteRule executeRule = executeRules.get(executeRuleIndex);
             boolean zeroRowsTransaction = false;
             for (Query query : executeRule.getQueries()) {
-                String queryStmt = query.getQuery();
-                PreparedStatement stmt = this.preparedStatementsPerQuery.get(queryStmt);
+                PreparedStatement stmt = this.preparedStatementsPerQuery.get(query);
                 List<UtilToMethod> baseUtils = query.getBaseUtils();
                 int count = query.getCount();
                 
@@ -505,7 +517,7 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                 isPGStatStatementCollected.set(true);
             }
 
-            if (((config.containsKey("execute") && config.getBoolean("execute")) || (executeRules == null || executeRules.isEmpty())) && !isCleanUpDone.get()) {
+            if ((executeCustom || !hasExecuteRules) && !isCleanUpDone.get()) {
                 try {
                     ybm.cleanUp(conn);
                 } catch (SQLException e) {

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/FeatureBenchWorker.java
@@ -56,8 +56,6 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
     // JSON (e.g. multi-row INSERTs inline every value). Beyond this length they are trimmed, since
     // only the standard SQL structure is of interest, not the actual bound values.
     private static final int MAX_COLLECTED_STRING_LENGTH = 1000;
-    static AtomicBoolean isCleanUpDone = new AtomicBoolean(false);
-    private final String workloadClass;
     private final HierarchicalConfiguration<ImmutableNode> config;
     private YBMicroBenchmark ybm;
     private final List<ExecuteRule> executeRules;
@@ -65,11 +63,17 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
     private HashMap<String, PreparedStatement> preparedStatementsPerQuery;
     public static Map<String,JSONObject> queryToExplainMap = new HashMap<>();
 
-    static AtomicBoolean isPGStatStatementCollected = new AtomicBoolean(false);
-
-    static AtomicBoolean isPGStatResetCalled = new AtomicBoolean(false);
-
     static AtomicBoolean isInitializeDone = new AtomicBoolean(false);
+
+    // tearDown() runs twice per worker -- once from the worker thread (Worker.run) and
+    // once from the master thread (ThreadBench.finalizeWorkers) -- and each worker closes
+    // its own connection at the end of tearDown(). These "run exactly once" guards make
+    // the global collection / user cleanup happen a single time, on the FIRST invocation,
+    // whose connection is still open. (A count/"last worker" gate is unsafe here: it fires
+    // on a later invocation whose connection has already been closed, which surfaces as a
+    // "connection closed" failure while collecting pg_stat_statements.)
+    static AtomicBoolean isPGStatStatementCollected = new AtomicBoolean(false);
+    static AtomicBoolean isCleanUpDone = new AtomicBoolean(false);
 
     public FeatureBenchWorker(FeatureBenchBenchmark benchmarkModule,
                               int id,
@@ -78,14 +82,13 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                               List<ExecuteRule> executeRules,
                               String workloadName) {
         super(benchmarkModule, id);
-        this.workloadClass = workloadClass;
         this.executeRules = executeRules;
         this.config = workerConfig;
         this.workloadName = workloadName;
-        isInitializeDone.set(false);
-        isPGStatResetCalled.set(false);
-        isPGStatStatementCollected.set(false);
-        isCleanUpDone.set(false);
+        // NOTE: per-workload shared state is reset once in
+        // FeatureBenchBenchmark.makeWorkersImpl (via resetSharedState()) before any
+        // worker is constructed -- not here -- so the "run once" guards do not depend
+        // on the ordering of individual worker constructors.
         try {
             ybm = (YBMicroBenchmark) Class.forName(workloadClass)
                 .getDeclaredConstructor(HierarchicalConfiguration.class)
@@ -93,6 +96,20 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Reset the shared, static per-workload state. Must be called exactly once per
+     * workload run, BEFORE the workers for that run are created (see
+     * FeatureBenchBenchmark.makeWorkersImpl). Doing it here rather than in each worker
+     * constructor keeps the "run once" guards correct regardless of construction order
+     * or worker reuse, and clears the accumulated explain output between workloads.
+     */
+    public static void resetSharedState() {
+        isInitializeDone.set(false);
+        isPGStatStatementCollected.set(false);
+        isCleanUpDone.set(false);
+        queryToExplainMap.clear();
     }
 
     protected void initialize() {
@@ -117,20 +134,19 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         if (isInitializeDone.get()) return;
         synchronized (FeatureBenchWorker.class) {
             if (isInitializeDone.get()) return;
-            if (!isPGStatResetCalled.get() &&
-                this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)
-            ) {
+            try {
+            if (this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false)) {
                 LOG.info("Resetting pg_stat_statements for workload : " + this.workloadName);
                 try {
                     Statement stmt = conn.createStatement();
                     stmt.executeQuery("SELECT pg_stat_statements_reset();");
                     if (!conn.getAutoCommit())
                         conn.commit();
-                    isPGStatResetCalled.set(true);
                 } catch (SQLException e) {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException("Failed to reset pg_stat_statements for workload '"
+                        + this.workloadName + "'. Is the pg_stat_statements extension installed?", e);
                 }
-                
+
             }
             // For Postgres, we need to reset pg_stat_user_indexes
             if (this.getWorkloadConfiguration().getDatabaseType().equals(DatabaseType.POSTGRES)) {
@@ -141,7 +157,8 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                     if (!conn.getAutoCommit())
                         conn.commit();
                 } catch (SQLException e) {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException("Failed to reset pg_stat (pg_stat_reset) for workload '"
+                        + this.workloadName + "'.", e);
                 }
             }
 
@@ -153,7 +170,8 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                     if (!conn.getAutoCommit())
                         conn.commit();
                 } catch (SQLException e) {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException("Failed to run ANALYZE for workload '"
+                        + this.workloadName + "'.", e);
                 }
             }
 
@@ -192,11 +210,10 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                                 stmt.setObject(j + 1, generatedValues[j]);
                             }
                             explainDDLMap.put(query.getQuery(), stmt);
-                        } catch (SQLException e) {
-                            throw new RuntimeException(e);
-                        } catch (ClassNotFoundException | InvocationTargetException | NoSuchMethodException |
+                        } catch (SQLException | ClassNotFoundException | InvocationTargetException | NoSuchMethodException |
                                  InstantiationException | IllegalAccessException e) {
-                            throw new RuntimeException(e);
+                            throw new RuntimeException("Failed to prepare EXPLAIN for query [" + querystmt
+                                + "] in workload '" + this.workloadName + "'.", e);
                         }
 
                     }
@@ -207,8 +224,24 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                     runExplainAnalyse(explainDDLMap);
             } catch (SQLException e) {
                 e.printStackTrace();
+            } finally {
+                // Explain statements are one-shot; close them here instead of leaking
+                // them on the connection for the whole run. runExplainAnalyse keeps the
+                // map pointing at the live statement even when it swaps one out for the
+                // dist/debug retry, so this closes the right handles.
+                for (PreparedStatement explainStmt : explainDDLMap.values()) {
+                    try {
+                        explainStmt.close();
+                    } catch (SQLException ignore) {
+                        // best-effort close
+                    }
+                }
             }
-            isInitializeDone.set(true);
+            } finally {
+                // Mark done even if a step above threw, so sibling threads blocked on
+                // the monitor do not re-run this once-only initialization work.
+                isInitializeDone.set(true);
+            }
         }
 
     }
@@ -223,19 +256,18 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
             int countResultSetGen = 0;
             boolean distOptionPresent = true;
             while (countResultSetGen < 3) {
-                try {
-                    ddl.executeQuery();
+                try (ResultSet ignored = ddl.executeQuery()) {
                     if(!conn.getAutoCommit())
                         conn.commit();
                 } catch (PSQLException e) {
                     if (distOptionPresent && e.getMessage().contains("unrecognized EXPLAIN option \"dist\"")) {
                         String modifiedQuery = ddl.toString().replace("dist,", "");
-                        ddl = conn.prepareStatement(modifiedQuery);
+                        ddl = swapStatement(entry, ddl, modifiedQuery);
                         distOptionPresent = false;
                         continue;
                     } else if (distOptionPresent && e.getMessage().contains("unrecognized EXPLAIN option \"debug\"")) {
                         String modifiedQuery = ddl.toString().replace("debug", "");
-                        ddl = conn.prepareStatement(modifiedQuery);
+                        ddl = swapStatement(entry, ddl, modifiedQuery);
                         distOptionPresent = false;
                         continue;
                     } else {
@@ -246,13 +278,14 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
             }
             jsonObject.put("SQL", trimToMaxLength(ddl.toString()));
             double explainStart = System.currentTimeMillis();
-            ResultSet rs = ddl.executeQuery();
-            if(!conn.getAutoCommit())
-                conn.commit();
             StringBuilder data = new StringBuilder();
-            while (rs.next()) {
-                data.append(rs.getString(1));
-                data.append("\n");
+            try (ResultSet rs = ddl.executeQuery()) {
+                if(!conn.getAutoCommit())
+                    conn.commit();
+                while (rs.next()) {
+                    data.append(rs.getString(1));
+                    data.append("\n");
+                }
             }
             double explainEnd = System.currentTimeMillis();
             jsonObject.put("ResultSet", data.toString());
@@ -276,6 +309,23 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         }
     }
 
+    /**
+     * Prepare a replacement explain statement (used for the dist/debug retry), close the
+     * old one, and update the map entry so the live statement is the one that gets closed
+     * by initialize()'s cleanup. Returns the replacement.
+     */
+    private PreparedStatement swapStatement(Map.Entry<String, PreparedStatement> entry,
+                                            PreparedStatement old, String newQuery) throws SQLException {
+        PreparedStatement replacement = conn.prepareStatement(newQuery);
+        entry.setValue(replacement);
+        try {
+            old.close();
+        } catch (SQLException ignore) {
+            // best-effort close of the statement we are replacing
+        }
+        return replacement;
+    }
+
 
     /**
      * Generates parameter values for a query, evaluating expressions with context from named references.
@@ -290,37 +340,49 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
             throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, 
                    InstantiationException, IllegalAccessException {
         
-        Object[] generatedValues = new Object[baseUtils.size()];
-        Map<String, Object> context = new HashMap<>();
-        
+        int size = baseUtils.size();
+        Object[] generatedValues = new Object[size];
+        // Allocated lazily: most queries have neither reference names nor expressions,
+        // so we avoid a throwaway HashMap on every execution in the worker hot loop.
+        Map<String, Object> context = null;
+        boolean hasExpression = false;
+
         // First pass: generate all non-expression values and build context
-        for (int j = 0; j < baseUtils.size(); j++) {
-            if (baseUtils.get(j).isExpression()) {
+        for (int j = 0; j < size; j++) {
+            UtilToMethod util = baseUtils.get(j);
+            if (util.isExpression()) {
                 // Skip expressions in first pass
+                hasExpression = true;
                 continue;
             }
-            Object value = baseUtils.get(j).get();
+            Object value = util.get();
             generatedValues[j] = value;
-            
+
             // Add to context if it has a reference name
-            if (baseUtils.get(j).getReferenceName() != null) {
-                context.put(baseUtils.get(j).getReferenceName(), value);
+            if (util.getReferenceName() != null) {
+                if (context == null) {
+                    context = new HashMap<>();
+                }
+                context.put(util.getReferenceName(), value);
             }
         }
-        
-        // Second pass: evaluate expressions with context
-        for (int j = 0; j < baseUtils.size(); j++) {
-            if (baseUtils.get(j).isExpression()) {
-                // This is an expression - evaluate it
-                BaseUtil util = baseUtils.get(j).getInstance();
-                if (util instanceof ExpressionEval) {
-                    ((ExpressionEval) util).setContext(context);
-                    Object value = baseUtils.get(j).get();
-                    generatedValues[j] = value;
+
+        // Second pass: evaluate expressions with context (skipped entirely when none)
+        if (hasExpression) {
+            Map<String, Object> ctx = (context != null) ? context : Collections.emptyMap();
+            for (int j = 0; j < size; j++) {
+                UtilToMethod utilMethod = baseUtils.get(j);
+                if (utilMethod.isExpression()) {
+                    // This is an expression - evaluate it
+                    BaseUtil util = utilMethod.getInstance();
+                    if (util instanceof ExpressionEval) {
+                        ((ExpressionEval) util).setContext(ctx);
+                        generatedValues[j] = utilMethod.get();
+                    }
                 }
             }
         }
-        
+
         return generatedValues;
     }
 
@@ -356,11 +418,15 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                         stmt.setObject(j + 1, generatedValues[j]);
                     }
                     
-                    if (query.isSelectQuery() || stmt.toString().toUpperCase().contains(" RETURNING ")) {
-                        ResultSet rs = stmt.executeQuery();
-                        int countSet = 0;
-                        while (rs.next()) countSet++;
-                        if (countSet == 0) zeroRowsTransaction = true;
+                    if (query.isSelectQuery() || query.isReturningQuery()) {
+                        // try-with-resources so the (possibly large) result set is
+                        // released as soon as we finish counting rows, rather than
+                        // lingering on the cached PreparedStatement until its next reuse.
+                        try (ResultSet rs = stmt.executeQuery()) {
+                            long countSet = 0;
+                            while (rs.next()) countSet++;
+                            if (countSet == 0) zeroRowsTransaction = true;
+                        }
                     } else {
                         int updatedRows = stmt.executeUpdate();
                         if (updatedRows == 0) zeroRowsTransaction = true;
@@ -382,8 +448,12 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
     @Override
     public void tearDown() {
         synchronized (FeatureBenchWorker.class) {
+            // Collect exactly once, on the first tearDown() invocation to get here (whose
+            // connection is still open). See the isPGStatStatementCollected/isCleanUpDone
+            // field comment for why a "last worker" gate is unsafe given tearDown() runs
+            // twice per worker and each worker closes its own connection.
             boolean shouldCollect = this.getWorkloadConfiguration().getXmlConfig().getBoolean("collect_pg_stat_statements", false);
-            if ( !this.getWorkloadConfiguration().getIsOptimalThreadsWorkload() && !this.configuration.getNewConnectionPerTxn() && (shouldCollect && !isPGStatStatementCollected.get()) && this.conn != null) {
+            if ( !isPGStatStatementCollected.get() && !this.getWorkloadConfiguration().getIsOptimalThreadsWorkload() && !this.configuration.getNewConnectionPerTxn() && shouldCollect && this.conn != null) {
 
                 Map<String, Integer> queryStringsAndRC = new LinkedHashMap<>();
                 for (ExecuteRule er : executeRules) {
@@ -400,10 +470,10 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                 try {
                     LOG.info("Collecting pg_stat_statements for workload : " + this.workloadName);
                     pgStatOutputs = callPGStats();
-                    
                     pgPreparedStatementOutputs = collectPgPreparedStatements();
                 } catch (SQLException e) {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException("Failed to collect pg_stat_statements / pg_prepared_statements for workload '"
+                        + this.workloadName + "'.", e);
                 }
 
                 // For Postgres, we need to collect pg_stat_user_indexes
@@ -412,7 +482,8 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                     try {
                         pgStatUserIndexesOutputs = callPGStatUserIndexes();
                     } catch (SQLException e) {
-                        throw new RuntimeException(e);
+                        throw new RuntimeException("Failed to collect pg_stat_user_indexes for workload '"
+                            + this.workloadName + "'.", e);
                     }
                 }
 
@@ -424,7 +495,6 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                     if (entry.getValue() != -1)
                         inner.put("explainPlanRcValidationSuccess", Integer.parseInt((String) queryToExplainMap.getOrDefault(entry.getKey(), new JSONObject()).get("ExplainPlanRows")) == entry.getValue());
                     inner.put("explain", queryToExplainMap.getOrDefault(entry.getKey(), new JSONObject()));
-                    
                     inner.put("prepared_statements", pgPreparedStatementOutputs == null ? new JSONObject() : pgPreparedStatementOutputs);
                     jsonResultsList.add(inner);
                 }
@@ -435,15 +505,14 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
                 isPGStatStatementCollected.set(true);
             }
 
-            if (((config.containsKey("execute") && config.getBoolean("execute")) || (executeRules == null || executeRules.isEmpty()) )&& !isCleanUpDone.get()) {
+            if (((config.containsKey("execute") && config.getBoolean("execute")) || (executeRules == null || executeRules.isEmpty())) && !isCleanUpDone.get()) {
                 try {
                     ybm.cleanUp(conn);
                 } catch (SQLException e) {
                     throw new RuntimeException(e);
                 }
                 LOG.info("\n=================Cleanup Phase taking from User=========\n");
-                    isCleanUpDone.set(true);
-
+                isCleanUpDone.set(true);
             }
 
             if (!this.configuration.getNewConnectionPerTxn() && this.conn != null) {
@@ -457,23 +526,71 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
     }
 
     private JSONObject callPGStats() throws SQLException{
-        String pgStatQuery = "select * from pg_stat_statements;";
-        Statement stmt = this.conn.createStatement();
-        ResultSet resultSet = stmt.executeQuery(pgStatQuery);
-        if(!conn.getAutoCommit())
-            conn.commit();
-        ResultSetMetaData rsmd = resultSet.getMetaData();
-        int resultSetCount = 0;
+        // Filter EXPLAIN rows server-side (findQueryInPgStatUsingCosine discards them
+        // anyway) so the in-memory snapshot stays smaller on busy clusters.
+        String pgStatQuery = "select * from pg_stat_statements where lower(btrim(query)) not like 'explain%';";
         JSONObject pgStatOutputs = new JSONObject();
-        while (resultSet.next()) {
-            JSONObject pgStatOutputPerRecord = new JSONObject();
-            for ( int i = 1; i <= rsmd.getColumnCount(); i++) {
-                pgStatOutputPerRecord.put(rsmd.getColumnName(i), resultSet.getString(i));
+        try (Statement stmt = this.conn.createStatement();
+             ResultSet resultSet = stmt.executeQuery(pgStatQuery)) {
+            if(!conn.getAutoCommit())
+                conn.commit();
+            ResultSetMetaData rsmd = resultSet.getMetaData();
+            int resultSetCount = 0;
+            while (resultSet.next()) {
+                JSONObject pgStatOutputPerRecord = new JSONObject();
+                for ( int i = 1; i <= rsmd.getColumnCount(); i++) {
+                    pgStatOutputPerRecord.put(rsmd.getColumnName(i), resultSet.getString(i));
+                }
+                pgStatOutputs.put("Record_" + resultSetCount, pgStatOutputPerRecord);
+                resultSetCount++;
             }
-            pgStatOutputs.put("Record_" + resultSetCount, pgStatOutputPerRecord);
-            resultSetCount++;
         }
         return pgStatOutputs;
+    }
+
+    /**
+     * Trims a collected SQL/explain string to {@link #MAX_COLLECTED_STRING_LENGTH} characters so the
+     * detailed results JSON stays small. The bound values (e.g. the VALUES (...) list of a multi-row
+     * INSERT) are not of interest — only the standard SQL structure is — so anything beyond the limit
+     * is dropped and replaced with a truncation marker noting how many characters were removed.
+     */
+    private static String trimToMaxLength(String value) {
+        if (value == null || value.length() <= MAX_COLLECTED_STRING_LENGTH) {
+            return value;
+        }
+        int trimmed = value.length() - MAX_COLLECTED_STRING_LENGTH;
+        return value.substring(0, MAX_COLLECTED_STRING_LENGTH) + "...[truncated " + trimmed + " chars]";
+    }
+
+    private JSONObject collectPgPreparedStatements() throws SQLException{
+        String pgPreparedStatements = "select * from pg_prepared_statements;";
+        JSONObject pgPreparedStatementOutputs = new JSONObject();
+        try (Statement stmt = this.conn.createStatement();
+             ResultSet resultSet = stmt.executeQuery(pgPreparedStatements)) {
+            if(!conn.getAutoCommit())
+                conn.commit();
+            ResultSetMetaData rsmd = resultSet.getMetaData();
+            int resultSetCount = 0;
+            while (resultSet.next()) {
+                JSONObject pgPreparedStatementOutputPerRecord = new JSONObject();
+                for ( int i = 1; i <= rsmd.getColumnCount(); i++) {
+                    String columnName = rsmd.getColumnName(i);
+                    // parameter_types can be very large for multi-row prepared statements; drop it entirely.
+                    if (columnName.equals("parameter_types")) {
+                        continue;
+                    }
+                    String value = resultSet.getString(i);
+                    // statement can be very large for multi-row INSERTs; trim it to the standard structure.
+                    if (columnName.equals("statement")) {
+                        value = trimToMaxLength(value);
+                    }
+                    pgPreparedStatementOutputPerRecord.put(columnName, value);
+                }
+                pgPreparedStatementOutputs.put("Record_" + resultSetCount, pgPreparedStatementOutputPerRecord);
+                resultSetCount++;
+            }
+        }
+        return pgPreparedStatementOutputs;
     }
 
     private List<String> tokenizeQuery(String query) {
@@ -552,67 +669,24 @@ public class FeatureBenchWorker extends Worker<FeatureBenchBenchmark> {
         return matchedKey != null ? (JSONObject) pgStatOutputs.get(matchedKey) : null;
     }
 
-    /**
-     * Trims a collected SQL/explain string to {@link #MAX_COLLECTED_STRING_LENGTH} characters so the
-     * detailed results JSON stays small. The bound values (e.g. the VALUES (...) list of a multi-row
-     * INSERT) are not of interest — only the standard SQL structure is — so anything beyond the limit
-     * is dropped and replaced with a truncation marker noting how many characters were removed.
-     */
-    private static String trimToMaxLength(String value) {
-        if (value == null || value.length() <= MAX_COLLECTED_STRING_LENGTH) {
-            return value;
-        }
-        int trimmed = value.length() - MAX_COLLECTED_STRING_LENGTH;
-        return value.substring(0, MAX_COLLECTED_STRING_LENGTH) + "...[truncated " + trimmed + " chars]";
-    }
-
-    private JSONObject collectPgPreparedStatements() throws SQLException{
-        String pgPreparedStatements = "select * from pg_prepared_statements;";
-        Statement stmt = this.conn.createStatement();
-        ResultSet resultSet = stmt.executeQuery(pgPreparedStatements);
-        if(!conn.getAutoCommit())
-            conn.commit();
-        ResultSetMetaData rsmd = resultSet.getMetaData();
-        int resultSetCount = 0;
-        JSONObject pgPreparedStatementOutputs = new JSONObject();
-        while (resultSet.next()) {
-            JSONObject pgPreparedStatementOutputPerRecord = new JSONObject();
-            for ( int i = 1; i <= rsmd.getColumnCount(); i++) {
-                String columnName = rsmd.getColumnName(i);
-                // parameter_types can be very large for multi-row prepared statements; drop it entirely.
-                if (columnName.equals("parameter_types")) {
-                    continue;
-                }
-                String value = resultSet.getString(i);
-                // statement can be very large for multi-row INSERTs; trim it to the standard structure.
-                if (columnName.equals("statement")) {
-                    value = trimToMaxLength(value);
-                }
-                pgPreparedStatementOutputPerRecord.put(columnName, value);
-            }
-            pgPreparedStatementOutputs.put("Record_" + resultSetCount, pgPreparedStatementOutputPerRecord);
-            resultSetCount++;
-        }
-        return pgPreparedStatementOutputs;
-    }
-
     private JSONArray callPGStatUserIndexes() throws SQLException{
         String pgStatUserIndexes = "SELECT relname AS table_name, seq_scan, idx_scan, seq_tup_read, idx_tup_fetch FROM pg_stat_user_tables;";
-        Statement stmt = this.conn.createStatement();
-        ResultSet resultSet = stmt.executeQuery(pgStatUserIndexes);
-        if(!conn.getAutoCommit())
-            conn.commit();
-        ResultSetMetaData rsmd = resultSet.getMetaData();
         JSONArray pgStatUserIndexesOutputs = new JSONArray();
-        while (resultSet.next()) {
-            JSONObject pgStatUserIndexesOutputPerRecord = new JSONObject();
-            for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-                pgStatUserIndexesOutputPerRecord.put(
-                    rsmd.getColumnName(i),
-                    resultSet.getString(i)
-                );
+        try (Statement stmt = this.conn.createStatement();
+             ResultSet resultSet = stmt.executeQuery(pgStatUserIndexes)) {
+            if(!conn.getAutoCommit())
+                conn.commit();
+            ResultSetMetaData rsmd = resultSet.getMetaData();
+            while (resultSet.next()) {
+                JSONObject pgStatUserIndexesOutputPerRecord = new JSONObject();
+                for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+                    pgStatUserIndexesOutputPerRecord.put(
+                        rsmd.getColumnName(i),
+                        resultSet.getString(i)
+                    );
+                }
+                pgStatUserIndexesOutputs.put(pgStatUserIndexesOutputPerRecord);
             }
-            pgStatUserIndexesOutputs.put(pgStatUserIndexesOutputPerRecord);
         }
         return pgStatUserIndexesOutputs;
     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/featurebench/workerhelpers/Query.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/featurebench/workerhelpers/Query.java
@@ -16,7 +16,7 @@ public class Query {
     public List<UtilToMethod> baseUtils;
     public boolean isSelectQuery = false;
     public boolean isUpdateQuery = false;
-    public List<String> referenceNames;
+    public boolean isReturningQuery = false;
 
     public List<UtilToMethod> getBaseUtils() {
         return baseUtils;
@@ -52,10 +52,20 @@ public class Query {
 
     public void setQuery(String query) {
         this.query = processQuery(query);
+        // Precompute once whether this statement returns a result set via a RETURNING
+        // clause (e.g. INSERT/UPDATE/DELETE ... RETURNING). Computing it here avoids
+        // calling PreparedStatement.toString() -- which rebuilds the full parameterized
+        // SQL string -- on every execution in the worker hot loop.
+        this.isReturningQuery = this.query != null
+            && this.query.toUpperCase().contains(" RETURNING ");
     }
 
     public boolean isSelectQuery() {
         return isSelectQuery;
+    }
+
+    public boolean isReturningQuery() {
+        return isReturningQuery;
     }
 
     public void setSelectQuery(boolean selectQuery) {
@@ -76,15 +86,6 @@ public class Query {
 
     public void setPattern_count(int pattern_count) {
         this.pattern_count = pattern_count;
-    }
-
-
-    public void setReferenceNames(List<String> referenceNames) {
-        this.referenceNames = referenceNames;
-    }
-
-    public List<String> getReferenceNames() {
-        return referenceNames;
     }
 
     public String processQuery(String query) {


### PR DESCRIPTION
## Heap / GC — execute hot path fixes
- ```try-with-resources``` on the result set in ```executeWork()``` — release each result set immediately instead of leaving it buffered on the cached statement, reducing GC pressure.
- Precomputed ```Query.isReturningQuery``` (replaces per-transaction stmt.toString()...contains(" RETURNING ")) — the old call rebuilt the full parameterized SQL string every transaction; now it's a one-time boolean.
- Lazy context map in ```generateParameterValues()``` — avoid allocating a throwaway HashMap per execution for queries with no reference/expression bindings.

## Init / teardown robustness
- ```resetSharedState()``` called once in makeWorkersImpl() instead of resetting flags in every worker constructor — makes the "run once" guards independent of worker construction order / reuse.
- Mark ```isInitializeDone``` in a finally — if the once-block throws, sibling threads don't re-run the one-time init work.
- Contextual ```RuntimeException``` messages on init/teardown failures — we want these to fail loudly; the messages now name the failed step + workload for faster diagnosis.
- ```try-with-resources``` in ```runExplainAnalyse``` and the pg_stat collectors; ```swapStatement()``` closes the statement replaced during the dist/debug retry; explain statements closed after use — stop leaking one-shot statements/result sets on the connection for the whole run.

## Cache execute/executeRules flags — FeatureBenchWorker

Replaced per-transaction ```config.containsKey("execute")/getBoolean(...)``` with ```final``` booleans ```executeCustom``` + ```hasExecuteRules``` resolved once in the constructor.
**Reason:** those ```HierarchicalConfiguration``` key-path lookups ran on every ```executeWork()``` call (the hot loop); they're constant per worker, so compute once.

## Key the prepared-statement cache by ```Query```, not SQL text — ```FeatureBenchWorker```

Changed ```preparedStatementsPerQuery``` from ```HashMap<String, PreparedStatement>``` to ```IdentityHashMap<Query, PreparedStatement>```.
**Reason:** string-keyed lookups did a full ```String.equals()``` over potentially huge SQL (multi-row INSERTs) on every query execution; keying by the ```Query``` object makes each lookup an identity hash + reference compare. Safe because each worker owns its own ```Query``` graph and connection.

## Make ```numberOfGeneratorFinished``` atomic — FeatureBenchLoader

Changed the ```static int``` counter to ```AtomicInteger (incrementAndGet() / get())```.
**Reason:** concurrent loader threads (```loaderthreads > 1```) did a non-atomic += 1 and an unsynchronized read; lost updates/stale reads meant the counter could miss ```sizeOfLoadRule``` and the ```afterLoad``` DDLs (e.g. post-load index creation) would silently never run. This is a correctness fix, not just perf.
